### PR TITLE
Add structured JSON logging with request ID correlation

### DIFF
--- a/guardian/audit.py
+++ b/guardian/audit.py
@@ -8,6 +8,8 @@ import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
+from taskrunner.log import request_id_var
+
 logger = logging.getLogger(__name__)
 
 
@@ -30,6 +32,10 @@ class AuditLogger:
 
     def _write(self, record: dict) -> None:
         """Append a JSON record to the log file."""
+        # Include request_id if set in current context
+        rid = request_id_var.get(None)
+        if rid is not None:
+            record["request_id"] = rid
         try:
             with open(self._path, "a") as f:
                 f.write(json.dumps(record, default=str) + "\n")

--- a/runner.py
+++ b/runner.py
@@ -342,6 +342,10 @@ def main() -> int:
         "--simple", action="store_true",
         help="Use simple stdin/stdout mode instead of TUI",
     )
+    parser.add_argument(
+        "--json-logs", action="store_true",
+        help="Output structured JSON log lines (for production)",
+    )
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
@@ -384,12 +388,10 @@ def main() -> int:
     args = parser.parse_args()
 
     # Set up logging
-    log_level = logging.DEBUG if args.verbose else logging.INFO
-    logging.basicConfig(
-        level=log_level,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
+    from taskrunner.log import setup_logging
+
+    log_level = "DEBUG" if args.verbose else "INFO"
+    setup_logging(json_mode=args.json_logs, level=log_level)
 
     # Load root .env if present (for PHONE, etc.)
     root_env = Path(".env")

--- a/taskrunner/chat.py
+++ b/taskrunner/chat.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 
 from taskrunner.agent import run_agent_loop
+from taskrunner.log import generate_request_id, request_id_var
 from taskrunner.models import AgentDefinition
 from taskrunner.session import SessionManager
 
@@ -46,6 +47,11 @@ class ChatServer:
 
         This is the callback passed to channels.
         """
+        # Set request ID for this message
+        rid = generate_request_id()
+        request_id_var.set(rid)
+        logger.info("Handling message from %s [request_id=%s]", sender_id, rid)
+
         stripped = text.strip()
 
         # Handle clear command

--- a/taskrunner/log.py
+++ b/taskrunner/log.py
@@ -1,0 +1,107 @@
+"""Structured logging with optional JSON output and request ID correlation."""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+
+# Context variable for threading request IDs through async call chains
+request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "request_id", default=None
+)
+
+
+def generate_request_id() -> str:
+    """Generate a short request ID (first 8 chars of a UUID4)."""
+    return uuid.uuid4().hex[:8]
+
+
+class JSONFormatter(logging.Formatter):
+    """Emit each log record as a single JSON line."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        entry: dict = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        # Include request_id from context var if set
+        rid = request_id_var.get(None)
+        if rid is not None:
+            entry["request_id"] = rid
+
+        # Include any extra fields passed via `extra`
+        for key in record.__dict__:
+            if key not in logging.LogRecord(
+                "", 0, "", 0, "", (), None
+            ).__dict__ and key not in ("message", "args"):
+                entry[key] = record.__dict__[key]
+
+        return json.dumps(entry, default=str)
+
+
+# Standard keys on a LogRecord — precomputed for performance
+_STANDARD_KEYS: set[str] | None = None
+
+
+def _standard_keys() -> set[str]:
+    global _STANDARD_KEYS
+    if _STANDARD_KEYS is None:
+        _STANDARD_KEYS = set(
+            logging.LogRecord("", 0, "", 0, "", (), None).__dict__.keys()
+        ) | {"message", "args"}
+    return _STANDARD_KEYS
+
+
+class _JSONFormatterOpt(logging.Formatter):
+    """Optimised JSON formatter (avoids creating a LogRecord each call)."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        entry: dict = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        rid = request_id_var.get(None)
+        if rid is not None:
+            entry["request_id"] = rid
+
+        std = _standard_keys()
+        for key, value in record.__dict__.items():
+            if key not in std:
+                entry[key] = value
+
+        return json.dumps(entry, default=str)
+
+
+def setup_logging(json_mode: bool = False, level: str = "INFO") -> None:
+    """Configure the root logger.
+
+    Args:
+        json_mode: If True, output structured JSON lines.
+        level: Log level name (e.g. "INFO", "DEBUG").
+    """
+    root = logging.getLogger()
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+
+    # Remove existing handlers to avoid duplicates
+    root.handlers.clear()
+
+    handler = logging.StreamHandler()
+
+    if json_mode:
+        handler.setFormatter(_JSONFormatterOpt())
+    else:
+        handler.setFormatter(logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        ))
+
+    root.addHandler(handler)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,100 @@
+"""Tests for structured JSON logging and request ID correlation."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from taskrunner.log import (
+    generate_request_id,
+    request_id_var,
+    setup_logging,
+)
+
+
+class TestJSONMode:
+    """Test JSON logging output."""
+
+    def test_json_mode_outputs_valid_json(self, capfd):
+        setup_logging(json_mode=True, level="DEBUG")
+        logger = logging.getLogger("test.json")
+        logger.info("hello world")
+
+        captured = capfd.readouterr()
+        record = json.loads(captured.err.strip())
+        assert record["level"] == "INFO"
+        assert record["logger"] == "test.json"
+        assert record["message"] == "hello world"
+        assert "timestamp" in record
+
+    def test_json_mode_includes_extra_fields(self, capfd):
+        setup_logging(json_mode=True, level="DEBUG")
+        logger = logging.getLogger("test.extra")
+        logger.info("with extra", extra={"foo": "bar"})
+
+        captured = capfd.readouterr()
+        record = json.loads(captured.err.strip())
+        assert record["foo"] == "bar"
+
+    def test_json_mode_includes_request_id(self, capfd):
+        setup_logging(json_mode=True, level="DEBUG")
+        token = request_id_var.set("test-rid-123")
+        try:
+            logger = logging.getLogger("test.rid")
+            logger.info("with rid")
+
+            captured = capfd.readouterr()
+            record = json.loads(captured.err.strip())
+            assert record["request_id"] == "test-rid-123"
+        finally:
+            request_id_var.reset(token)
+
+
+class TestHumanReadableMode:
+    """Test that human-readable mode still works."""
+
+    def test_human_readable_format(self, capfd):
+        setup_logging(json_mode=False, level="DEBUG")
+        logger = logging.getLogger("test.human")
+        logger.info("readable message")
+
+        captured = capfd.readouterr()
+        line = captured.err.strip()
+        assert "readable message" in line
+        assert "[INFO]" in line
+        assert "test.human" in line
+        # Should NOT be valid JSON
+        try:
+            json.loads(line)
+            assert False, "Should not be valid JSON"
+        except json.JSONDecodeError:
+            pass
+
+
+class TestRequestId:
+    """Test request ID generation and context propagation."""
+
+    def test_generate_request_id_format(self):
+        rid = generate_request_id()
+        assert len(rid) == 8
+        # Should be hex characters
+        int(rid, 16)
+
+    def test_generate_request_id_unique(self):
+        ids = {generate_request_id() for _ in range(100)}
+        assert len(ids) == 100
+
+    def test_request_id_context_var_default(self):
+        # Reset to default
+        token = request_id_var.set(None)
+        try:
+            assert request_id_var.get() is None
+        finally:
+            request_id_var.reset(token)
+
+    def test_request_id_propagation(self):
+        token = request_id_var.set("abc123")
+        try:
+            assert request_id_var.get() == "abc123"
+        finally:
+            request_id_var.reset(token)


### PR DESCRIPTION
## Summary

Adds a structured JSON logging option for production use (Phase 1.5).

### Changes

- **`taskrunner/log.py`** — New module with `setup_logging(json_mode, level)`, custom JSON formatter, `request_id_var` context var, and `generate_request_id()` helper
- **`runner.py`** — Added `--json-logs` CLI flag
- **`taskrunner/chat.py`** — Sets request ID at start of each `handle_message()` call, propagates through agent loop and tool calls
- **`guardian/audit.py`** — Includes `request_id` in all audit log entries when set
- **`tests/test_logging.py`** — 8 tests covering JSON output, human-readable mode, extra fields, and request ID propagation

### Details

- No external dependencies — stdlib only (`logging` + `json` + `contextvars`)
- JSON mode emits one JSON object per line with: `timestamp`, `level`, `logger`, `message`, plus `request_id` and any `extra` fields
- Human-readable mode unchanged from current behavior