### PR TITLE
feat: graceful shutdown (SIGTERM/SIGINT)

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -296,16 +296,30 @@ def cmd_listen(args: argparse.Namespace) -> int:
 
     server = ChatServer(agent_def, use_containers=args.containers, imessage_channel=imessage_channel)
 
+    # Set up graceful shutdown on SIGTERM/SIGINT
+    import signal
+
+    def _handle_shutdown(signum, frame):
+        sig_name = signal.Signals(signum).name
+        logger.info("Received %s, initiating graceful shutdown...", sig_name)
+        print(f"\nReceived {sig_name}, shutting down...")
+        channel.stop()
+
+    signal.signal(signal.SIGTERM, _handle_shutdown)
+    signal.signal(signal.SIGINT, _handle_shutdown)
+
     try:
         channel.listen(server.handle_message)
     except KeyboardInterrupt:
-        print("\nListener stopped.")
+        pass
 
+    print("Listener stopped.")
     return 0
 
 
 def cmd_serve(args: argparse.Namespace) -> int:
     """Start message listener + scheduler (daemon mode)."""
+    import signal
     import threading
 
     from taskrunner.chat import ChatServer
@@ -366,11 +380,25 @@ def cmd_serve(args: argparse.Namespace) -> int:
 
     server = ChatServer(agent_def, use_containers=args.containers, imessage_channel=imessage_channel)
 
+    # Set up graceful shutdown on SIGTERM/SIGINT
+    shutdown_event = threading.Event()
+
+    def _handle_shutdown(signum, frame):
+        sig_name = signal.Signals(signum).name
+        logger.info("Received %s, initiating graceful shutdown...", sig_name)
+        print(f"\nReceived {sig_name}, shutting down...")
+        shutdown_event.set()
+        channel.stop()
+
+    signal.signal(signal.SIGTERM, _handle_shutdown)
+    signal.signal(signal.SIGINT, _handle_shutdown)
+
     try:
         channel.listen(server.handle_message)
     except KeyboardInterrupt:
-        print("\nServer stopped.")
+        pass
 
+    print("Server stopped.")
     return 0
 
 

--- a/taskrunner/channels/__init__.py
+++ b/taskrunner/channels/__init__.py
@@ -9,6 +9,8 @@ from typing import Callable
 class Channel(ABC):
     """Base class for communication channels."""
 
+    _stop_requested: bool = False
+
     @abstractmethod
     def listen(self, callback: Callable[[str, str], str]) -> None:
         """Listen for incoming messages.
@@ -20,3 +22,7 @@ class Channel(ABC):
     @abstractmethod
     def send(self, recipient: str, text: str) -> None:
         """Send a message to a recipient."""
+
+    def stop(self) -> None:
+        """Request the channel to stop listening."""
+        self._stop_requested = True

--- a/taskrunner/channels/bluebubbles.py
+++ b/taskrunner/channels/bluebubbles.py
@@ -45,7 +45,7 @@ class BlueBubblesChannel(Channel):
             ", ".join(self._allowed_senders),
         )
 
-        while True:
+        while not self._stop_requested:
             try:
                 messages = self._poll(last_ts)
                 for msg in messages:
@@ -62,6 +62,8 @@ class BlueBubblesChannel(Channel):
                 logger.exception("Error polling BlueBubbles")
 
             time.sleep(self._poll_interval)
+
+        logger.info("BlueBubbles listener stopped")
 
     def send(self, recipient: str, text: str) -> None:
         """Send a message via BlueBubbles REST API."""

--- a/taskrunner/channels/imessage.py
+++ b/taskrunner/channels/imessage.py
@@ -52,7 +52,7 @@ class IMessageChannel(Channel):
             last_rowid,
         )
 
-        while True:
+        while not self._stop_requested:
             try:
                 new_messages = self._poll(last_rowid)
                 for msg in new_messages:
@@ -66,6 +66,8 @@ class IMessageChannel(Channel):
                 logger.exception("Error polling messages")
 
             time.sleep(self._poll_interval)
+
+        logger.info("iMessage listener stopped")
 
     def send(self, recipient: str, text: str) -> None:
         """Send an iMessage via AppleScript."""

--- a/taskrunner/scheduler.py
+++ b/taskrunner/scheduler.py
@@ -17,19 +17,26 @@ logger = logging.getLogger(__name__)
 def start_scheduler(
     tasks_dir: str | Path = "tasks",
     use_containers: bool = False,
-) -> None:
+    shutdown_event: "threading.Event | None" = None,
+) -> BlockingScheduler:
     """Load all tasks and start the blocking scheduler.
 
     Args:
         tasks_dir: Directory containing task YAML files.
         use_containers: Whether to run executors/LLM in Docker containers.
+        shutdown_event: Optional threading.Event; when set, shuts down the scheduler.
+
+    Returns:
+        The scheduler instance (useful for external shutdown).
     """
+    import threading
+
     tasks_dir = Path(tasks_dir)
     tasks = load_all_tasks(tasks_dir)
 
     if not tasks:
         logger.warning("No tasks found in %s", tasks_dir)
-        return
+        return BlockingScheduler()
 
     scheduler = BlockingScheduler()
 
@@ -46,6 +53,16 @@ def start_scheduler(
             name=task.name,
         )
 
+    # If a shutdown event is provided, watch it in a background thread
+    if shutdown_event is not None:
+        def _watch_shutdown():
+            shutdown_event.wait()
+            logger.info("Shutdown event received, stopping scheduler")
+            scheduler.shutdown(wait=False)
+
+        watcher = threading.Thread(target=_watch_shutdown, daemon=True)
+        watcher.start()
+
     logger.info("Starting scheduler with %d tasks", len(tasks))
 
     try:
@@ -53,6 +70,8 @@ def start_scheduler(
     except KeyboardInterrupt:
         logger.info("Scheduler stopped by user")
         scheduler.shutdown()
+
+    return scheduler
 
 
 def _run_task_safe(task_path: str, use_containers: bool) -> None:


### PR DESCRIPTION
## Summary
Add signal handlers for clean shutdown in serve and listen modes.

## Changes
- `Channel` base class gains `stop()` method and `_stop_requested` flag
- iMessage and BlueBubbles channels check flag in their poll loops
- `cmd_serve` and `cmd_listen` install SIGTERM/SIGINT handlers
- Scheduler accepts optional `shutdown_event` for external shutdown
- Both signals trigger graceful stop of channel listener + scheduler