### PR TITLE
feat: integration smoke test (full serve pipeline)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,50 @@
+"""Shared test fixtures for the Creel test suite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from taskrunner.models import (
+    AgentConfig,
+    AgentDefinition,
+    ChannelsConfig,
+    LLMConfig,
+    SessionConfig,
+    WorkspaceConfig,
+)
+
+
+@pytest.fixture
+def tmp_sessions_dir(tmp_path: Path) -> str:
+    """Return a temporary sessions directory path."""
+    d = tmp_path / "sessions"
+    d.mkdir()
+    return str(d)
+
+
+@pytest.fixture
+def minimal_agent_def(tmp_sessions_dir: str) -> AgentDefinition:
+    """Create a minimal AgentDefinition for testing."""
+    return AgentDefinition(
+        system_prompt="You are a helpful assistant.",
+        llm=LLMConfig(model="claude-sonnet-4-20250514", max_tokens=100),
+        agent=AgentConfig(max_turns=5),
+        session=SessionConfig(sessions_dir=tmp_sessions_dir, max_history=50),
+        workspace=WorkspaceConfig(path="/tmp/nonexistent-workspace"),
+        channels=ChannelsConfig(),
+    )
+
+
+@pytest.fixture
+def mock_llm_response() -> MagicMock:
+    """Create a mock Anthropic Message with a single text block."""
+    block = MagicMock()
+    block.type = "text"
+    block.text = "Hello from the mock LLM!"
+    msg = MagicMock()
+    msg.content = [block]
+    msg.stop_reason = "end_turn"
+    return msg

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,134 @@
+"""Integration smoke test — full pipeline from message to response."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from taskrunner.chat import ChatServer
+from taskrunner.models import AgentDefinition
+
+
+class TestFullPipeline:
+    """End-to-end: incoming message → ChatServer → agent loop → mock LLM → response."""
+
+    @patch("taskrunner.agent.call_llm")
+    def test_stdin_to_response(
+        self, mock_call_llm, minimal_agent_def: AgentDefinition, monkeypatch
+    ):
+        """A user message should flow through ChatServer and return a text response."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+        # Mock LLM returns a simple text response (no tool calls)
+        block = MagicMock()
+        block.type = "text"
+        block.text = "The weather is sunny today!"
+        response = MagicMock()
+        response.content = [block]
+        response.stop_reason = "end_turn"
+        mock_call_llm.return_value = response
+
+        server = ChatServer(minimal_agent_def, use_containers=False)
+        result = server.handle_message("test-user", "What's the weather?")
+
+        assert "sunny" in result
+        mock_call_llm.assert_called()
+        # Verify the user message was passed through
+        call_kwargs = mock_call_llm.call_args
+        messages = call_kwargs.kwargs.get("messages") or call_kwargs[1].get("messages") or call_kwargs[0][0]
+        assert any(
+            m.get("content") == "What's the weather?"
+            for m in messages
+            if isinstance(m, dict)
+        )
+
+    @patch("taskrunner.agent.call_llm")
+    def test_session_persists_across_messages(
+        self, mock_call_llm, minimal_agent_def: AgentDefinition, monkeypatch
+    ):
+        """Multiple messages from the same sender should share a session."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+        block = MagicMock()
+        block.type = "text"
+        block.text = "Response"
+        response = MagicMock()
+        response.content = [block]
+        response.stop_reason = "end_turn"
+        mock_call_llm.return_value = response
+
+        server = ChatServer(minimal_agent_def, use_containers=False)
+        server.handle_message("test-user", "First message")
+        server.handle_message("test-user", "Second message")
+
+        # Second call should have both messages in history
+        second_call = mock_call_llm.call_args_list[1]
+        messages = second_call.kwargs.get("messages") or second_call[1].get("messages") or second_call[0][0]
+        user_messages = [m for m in messages if isinstance(m, dict) and m.get("role") == "user" and isinstance(m.get("content"), str)]
+        assert len(user_messages) >= 2
+
+    @patch("taskrunner.agent.call_llm")
+    def test_clear_resets_session(
+        self, mock_call_llm, minimal_agent_def: AgentDefinition, monkeypatch
+    ):
+        """The 'clear' command should reset the session."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+        block = MagicMock()
+        block.type = "text"
+        block.text = "Hi"
+        response = MagicMock()
+        response.content = [block]
+        response.stop_reason = "end_turn"
+        mock_call_llm.return_value = response
+
+        server = ChatServer(minimal_agent_def, use_containers=False)
+        server.handle_message("test-user", "Hello")
+        result = server.handle_message("test-user", "clear")
+        assert "cleared" in result.lower()
+
+    @patch("taskrunner.agent.call_llm")
+    def test_tool_call_round_trip(
+        self, mock_call_llm, minimal_agent_def: AgentDefinition, monkeypatch
+    ):
+        """Agent loop should handle a tool call and return final text."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+        # First call: LLM wants to use a tool
+        tool_block = MagicMock()
+        tool_block.type = "tool_use"
+        tool_block.id = "tool_123"
+        tool_block.name = "test_tool"
+        tool_block.input = {"query": "test"}
+        first_response = MagicMock()
+        first_response.content = [tool_block]
+        first_response.stop_reason = "tool_use"
+
+        # Second call: LLM gives final text
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = "Here is the result!"
+        second_response = MagicMock()
+        second_response.content = [text_block]
+        second_response.stop_reason = "end_turn"
+
+        mock_call_llm.side_effect = [first_response, second_response]
+
+        # Add a tool to the agent definition
+        from taskrunner.models import ToolConfig
+        minimal_agent_def.tools = {
+            "test_tool": ToolConfig(
+                executor="weather",
+                description="Test tool",
+            )
+        }
+
+        server = ChatServer(minimal_agent_def, use_containers=False)
+
+        # Mock the tool execution
+        with patch("taskrunner.agent.execute_tool_call", return_value="Tool output"):
+            result = server.handle_message("test-user", "Use the tool")
+
+        assert "result" in result.lower() or "Here is" in result
+        assert mock_call_llm.call_count == 2


### PR DESCRIPTION
## Summary
Add integration smoke tests covering the full message pipeline, plus shared test fixtures.

## Changes
- `tests/conftest.py`: Shared fixtures (`minimal_agent_def`, `mock_llm_response`, `tmp_sessions_dir`)
- `tests/test_integration.py`: 4 integration tests:
  - Message → ChatServer → agent loop → mock LLM → response
  - Session persistence across multiple messages
  - Clear command resets session
  - Tool call round-trip (tool_use → execute → final response)

Closes the integration test gap — CI pipeline already exists, this adds the actual tests.