### PR TITLE
feat: iMessage/BlueBubbles poll backoff on errors

### DIFF
--- a/taskrunner/channels/bluebubbles.py
+++ b/taskrunner/channels/bluebubbles.py
@@ -45,9 +45,13 @@ class BlueBubblesChannel(Channel):
             ", ".join(self._allowed_senders),
         )
 
+        consecutive_errors = 0
+        max_backoff = 60  # seconds
+
         while not self._stop_requested:
             try:
                 messages = self._poll(last_ts)
+                consecutive_errors = 0  # reset on success
                 for msg in messages:
                     sender = msg["sender"]
                     ts = msg["timestamp"]
@@ -59,7 +63,14 @@ class BlueBubblesChannel(Channel):
                     if ts > last_ts:
                         last_ts = ts
             except Exception:
-                logger.exception("Error polling BlueBubbles")
+                consecutive_errors += 1
+                backoff = min(self._poll_interval * (2 ** consecutive_errors), max_backoff)
+                logger.exception(
+                    "Error polling BlueBubbles (consecutive=%d, backoff=%.1fs)",
+                    consecutive_errors, backoff,
+                )
+                time.sleep(backoff)
+                continue
 
             time.sleep(self._poll_interval)
 

--- a/taskrunner/channels/imessage.py
+++ b/taskrunner/channels/imessage.py
@@ -52,9 +52,13 @@ class IMessageChannel(Channel):
             last_rowid,
         )
 
+        consecutive_errors = 0
+        max_backoff = 60  # seconds
+
         while not self._stop_requested:
             try:
                 new_messages = self._poll(last_rowid)
+                consecutive_errors = 0  # reset on success
                 for msg in new_messages:
                     sender = msg["sender"]
                     if sender in self._allowed_senders:
@@ -63,7 +67,14 @@ class IMessageChannel(Channel):
                         self.send(sender, response)
                     last_rowid = max(last_rowid, msg["rowid"])
             except Exception:
-                logger.exception("Error polling messages")
+                consecutive_errors += 1
+                backoff = min(self._poll_interval * (2 ** consecutive_errors), max_backoff)
+                logger.exception(
+                    "Error polling messages (consecutive=%d, backoff=%.1fs)",
+                    consecutive_errors, backoff,
+                )
+                time.sleep(backoff)
+                continue
 
             time.sleep(self._poll_interval)
 


### PR DESCRIPTION
## Summary
Add exponential backoff when polling fails in iMessage and BlueBubbles channels.

## Changes
- Both channels track consecutive error count
- On error: sleep `poll_interval * 2^errors` (capped at 60s)
- On success: reset error counter to 0
- Prevents tight error loops when chat.db is locked or BlueBubbles server is down