### PR TITLE
feat: session TTL / auto-expiry

### DIFF
--- a/taskrunner/chat.py
+++ b/taskrunner/chat.py
@@ -42,6 +42,7 @@ class ChatServer:
         self._session_mgr = SessionManager(
             sessions_dir=agent_def.session.sessions_dir,
             max_history=agent_def.session.max_history,
+            ttl_hours=agent_def.session.ttl_hours,
         )
 
         # Initialize memory manager if workspace is configured

--- a/taskrunner/models.py
+++ b/taskrunner/models.py
@@ -88,6 +88,7 @@ class SessionConfig(BaseModel):
     sessions_dir: str = "sessions"
     max_history: int = 50
     summarize_on_trim: bool = True
+    ttl_hours: float = 0  # 0 = no expiry
 
 
 class WorkspaceConfig(BaseModel):

--- a/taskrunner/session.py
+++ b/taskrunner/session.py
@@ -30,26 +30,64 @@ class Session:
 class SessionManager:
     """Manages conversation sessions persisted as JSON files."""
 
-    def __init__(self, sessions_dir: str = "sessions", max_history: int = 50):
+    def __init__(self, sessions_dir: str = "sessions", max_history: int = 50, ttl_hours: float = 0):
         self._dir = Path(sessions_dir)
         self._dir.mkdir(parents=True, exist_ok=True)
         self._max_history = max_history
+        self._ttl_seconds = ttl_hours * 3600 if ttl_hours > 0 else 0
 
     # -- public API --
 
     def get_or_create(self, sender_id: str) -> Session:
-        """Load the active session from the index, or create a new one."""
+        """Load the active session from the index, or create a new one.
+
+        If TTL is configured and the active session has expired, a new session
+        is created automatically.
+        """
         active_id = self._get_active_session_id(sender_id)
         if active_id:
             session = self._load(active_id)
             if session is not None:
-                return session
+                if self._is_expired(session):
+                    logger.info(
+                        "Session %s expired (last_active=%.0f), starting new session",
+                        session.session_id, session.last_active,
+                    )
+                else:
+                    return session
 
-        # No active session (or file missing) — create fresh
+        # No active session (or file missing or expired) — create fresh
         session = Session(sender_id=sender_id)
         self._set_active_session_id(sender_id, session.session_id)
         logger.info("Created new session %s for %s", session.session_id, sender_id)
         return session
+
+    def _is_expired(self, session: Session) -> bool:
+        """Check if a session has exceeded the TTL."""
+        if not self._ttl_seconds:
+            return False
+        return (time.time() - session.last_active) > self._ttl_seconds
+
+    def cleanup_expired(self, sender_id: str) -> int:
+        """Remove expired sessions for a sender. Returns count of removed sessions."""
+        if not self._ttl_seconds:
+            return 0
+        removed = 0
+        for path in self._dir.glob("*.json"):
+            if path.name == _ACTIVE_INDEX_FILE:
+                continue
+            try:
+                data = json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError):
+                continue
+            if data.get("sender_id") != sender_id:
+                continue
+            last_active = data.get("last_active", 0)
+            if (time.time() - last_active) > self._ttl_seconds:
+                path.unlink()
+                removed += 1
+                logger.info("Removed expired session %s", path.stem)
+        return removed
 
     def new_session(self, sender_id: str) -> Session:
         """Save the current session and start a fresh one."""

--- a/tests/test_session_ttl.py
+++ b/tests/test_session_ttl.py
@@ -1,0 +1,71 @@
+"""Tests for session TTL / auto-expiry."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from taskrunner.session import Session, SessionManager
+
+
+class TestSessionTTL:
+    """Tests for TTL-based session expiry."""
+
+    def test_no_ttl_sessions_never_expire(self, tmp_path: Path):
+        mgr = SessionManager(sessions_dir=str(tmp_path), ttl_hours=0)
+        s = mgr.add_user_message("cli", "Hello")
+        # Manually set last_active to way in the past
+        s.last_active = time.time() - 999999
+        mgr._save(s)
+        loaded = mgr.get_or_create("cli")
+        assert loaded.session_id == s.session_id
+
+    def test_expired_session_creates_new(self, tmp_path: Path):
+        mgr = SessionManager(sessions_dir=str(tmp_path), ttl_hours=1)
+        s = mgr.add_user_message("cli", "Hello")
+        old_id = s.session_id
+        # Set last_active to 2 hours ago
+        s.last_active = time.time() - 7200
+        mgr._save(s)
+        new_session = mgr.get_or_create("cli")
+        assert new_session.session_id != old_id
+        assert new_session.messages == []
+
+    def test_non_expired_session_reused(self, tmp_path: Path):
+        mgr = SessionManager(sessions_dir=str(tmp_path), ttl_hours=24)
+        s = mgr.add_user_message("cli", "Hello")
+        loaded = mgr.get_or_create("cli")
+        assert loaded.session_id == s.session_id
+
+    def test_cleanup_expired_removes_old(self, tmp_path: Path):
+        mgr = SessionManager(sessions_dir=str(tmp_path), ttl_hours=1)
+        s = mgr.add_user_message("cli", "Hello")
+        s.last_active = time.time() - 7200
+        mgr._save(s)
+        removed = mgr.cleanup_expired("cli")
+        assert removed == 1
+        # File should be gone
+        assert not (tmp_path / f"{s.session_id}.json").exists()
+
+    def test_cleanup_expired_keeps_recent(self, tmp_path: Path):
+        mgr = SessionManager(sessions_dir=str(tmp_path), ttl_hours=1)
+        s = mgr.add_user_message("cli", "Hello")
+        removed = mgr.cleanup_expired("cli")
+        assert removed == 0
+        assert (tmp_path / f"{s.session_id}.json").exists()
+
+    def test_cleanup_no_ttl_returns_zero(self, tmp_path: Path):
+        mgr = SessionManager(sessions_dir=str(tmp_path), ttl_hours=0)
+        mgr.add_user_message("cli", "Hello")
+        assert mgr.cleanup_expired("cli") == 0
+
+    def test_ttl_config_in_model(self):
+        from taskrunner.models import SessionConfig
+        cfg = SessionConfig(ttl_hours=48)
+        assert cfg.ttl_hours == 48
+        cfg2 = SessionConfig()
+        assert cfg2.ttl_hours == 0


### PR DESCRIPTION
## Summary
Add configurable TTL to sessions so old conversations automatically expire.

## Changes
- `SessionConfig.ttl_hours` field (default 0 = disabled)
- `SessionManager` checks TTL on `get_or_create()` — expired sessions create a new one
- `cleanup_expired(sender_id)` method to remove old session files
- ChatServer passes `ttl_hours` from config

## Testing
7 new tests covering expiry logic, cleanup, and configuration