### PR TITLE
refactor: clean up session save API

### DIFF
--- a/taskrunner/chat.py
+++ b/taskrunner/chat.py
@@ -155,11 +155,11 @@ class ChatServer:
             )
             self._send_approval_request(sender_id, action)
             # Save session state
-            self._session_mgr._save(session)
+            self._session_mgr.save_session(session)
             return "⏳ Waiting for your approval to proceed."
 
         # Save the updated messages (agent loop mutates the list)
-        self._session_mgr._save(session)
+        self._session_mgr.save_session(session)
 
         return result.text
 

--- a/taskrunner/session.py
+++ b/taskrunner/session.py
@@ -127,6 +127,13 @@ class SessionManager:
         session.last_active = time.time()
         self._save(session)
 
+    def save_session(self, session: Session) -> None:
+        """Save a session to disk (public API).
+
+        Trims messages to max_history and persists to the session file.
+        """
+        self._save(session)
+
     def clear(self, sender_id: str) -> None:
         """Clear the active session's messages (keeps file, resets messages)."""
         active_id = self._get_active_session_id(sender_id)


### PR DESCRIPTION
## Summary
Expose a proper public `save_session()` method on `SessionManager` instead of callers reaching into the private `_save()` method.

## Changes
- Added `SessionManager.save_session(session)` as public API
- Updated both callers in `chat.py` from `_save()` to `save_session()`
- `_save()` remains as internal implementation