### PR TITLE
feat: smart session trimming (preserve tool-call pairs)

### DIFF
--- a/taskrunner/session.py
+++ b/taskrunner/session.py
@@ -146,12 +146,18 @@ class SessionManager:
     def _ensure_valid_start(messages: list[dict]) -> list[dict]:
         """Strip orphaned messages so the list starts with a user text message.
 
-        After trimming by max_history, the list may begin with a user
-        ``tool_result`` message whose matching assistant ``tool_use`` was
-        trimmed away, or with an assistant message.  The Anthropic API
-        requires the first message to be a ``user`` message with text
-        content, so we drop leading messages until that invariant holds.
+        After trimming by max_history, the list may begin mid-tool-call
+        (e.g. with an assistant tool_use whose tool_result comes next, or
+        a user tool_result whose matching tool_use was trimmed away).
+
+        This method finds the first position where a complete,
+        non-tool-call user text message begins and drops everything before it.
+        This ensures we never start mid-tool-call.
         """
+        # Find the first user text message that is NOT followed by being
+        # part of an orphaned tool-call sequence.  The simplest safe rule:
+        # walk forward until we find a user message with string content
+        # that is NOT a tool_result.
         while messages:
             msg = messages[0]
             if msg.get("role") == "user" and isinstance(msg.get("content"), str):
@@ -159,11 +165,44 @@ class SessionManager:
             messages.pop(0)
         return messages
 
+    @staticmethod
+    def _trim_preserving_tool_pairs(messages: list[dict], max_history: int) -> list[dict]:
+        """Trim messages to max_history while keeping complete tool-call pairs.
+
+        A tool-call sequence is:
+          1. assistant message with tool_use block(s)
+          2. user message with tool_result block(s)
+
+        We never split these apart. After naive trimming, we scan from the
+        start to find the first safe boundary (a user text message not part
+        of an incomplete tool-call pair).
+        """
+        if len(messages) <= max_history:
+            return messages
+
+        # Start with naive trim from the end
+        trimmed = messages[-max_history:]
+
+        # Now find first safe start point
+        i = 0
+        while i < len(trimmed):
+            msg = trimmed[i]
+            # A user message with string content (not tool_result) is safe
+            if msg.get("role") == "user" and isinstance(msg.get("content"), str):
+                break
+            # An assistant message with only text blocks (no tool_use) is safe
+            # if it's followed by a user text message, but we prefer starting
+            # with user messages for API compatibility
+            i += 1
+
+        return trimmed[i:]
+
     def _save(self, session: Session) -> None:
         """Write session to disk, trimming to max_history."""
         if len(session.messages) > self._max_history:
-            session.messages = session.messages[-self._max_history:]
-            self._ensure_valid_start(session.messages)
+            session.messages = self._trim_preserving_tool_pairs(
+                session.messages, self._max_history,
+            )
 
         data = {
             "session_id": session.session_id,
@@ -194,8 +233,9 @@ class SessionManager:
                 last_active=data.get("last_active", time.time()),
             )
             if len(session.messages) > self._max_history:
-                session.messages = session.messages[-self._max_history:]
-                self._ensure_valid_start(session.messages)
+                session.messages = self._trim_preserving_tool_pairs(
+                    session.messages, self._max_history,
+                )
             return session
         except (json.JSONDecodeError, KeyError) as e:
             logger.warning("Corrupt session file %s, ignoring: %s", session_id, e)

--- a/tests/test_smart_trimming.py
+++ b/tests/test_smart_trimming.py
@@ -1,0 +1,131 @@
+"""Tests for smart session trimming that preserves tool-call pairs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from taskrunner.session import SessionManager
+
+
+def _tool_call_conversation() -> list[dict]:
+    """Build a conversation with tool calls for testing."""
+    return [
+        {"role": "user", "content": "What's the weather?"},
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t1", "name": "weather", "input": {"city": "Denver"}},
+        ]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t1", "content": "Sunny, 72°F"},
+        ]},
+        {"role": "assistant", "content": [{"type": "text", "text": "It's sunny!"}]},
+        {"role": "user", "content": "Thanks"},
+        {"role": "assistant", "content": [{"type": "text", "text": "You're welcome!"}]},
+        {"role": "user", "content": "What about tomorrow?"},
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t2", "name": "weather", "input": {"city": "Denver", "day": "tomorrow"}},
+        ]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t2", "content": "Partly cloudy, 65°F"},
+        ]},
+        {"role": "assistant", "content": [{"type": "text", "text": "Partly cloudy tomorrow!"}]},
+    ]
+
+
+class TestSmartTrimming:
+    """Tests that trimming never breaks mid-tool-call."""
+
+    def test_trim_starts_at_user_text(self, tmp_path: Path):
+        """Trimmed history should start with a user text message, not a tool_result."""
+        mgr = SessionManager(sessions_dir=str(tmp_path), max_history=6)
+        session = mgr.get_or_create("cli")
+        session.messages = _tool_call_conversation()  # 10 messages
+        mgr._save(session)
+
+        loaded = mgr.get_or_create("cli")
+        assert loaded.messages[0]["role"] == "user"
+        assert isinstance(loaded.messages[0]["content"], str)
+
+    def test_trim_never_starts_with_tool_result(self, tmp_path: Path):
+        """With max_history=5, naive trim would start at tool_result. Smart trim skips it."""
+        mgr = SessionManager(sessions_dir=str(tmp_path), max_history=5)
+        session = mgr.get_or_create("cli")
+        session.messages = _tool_call_conversation()
+        mgr._save(session)
+
+        loaded = mgr.get_or_create("cli")
+        first = loaded.messages[0]
+        # Should never be a tool_result
+        assert not (first["role"] == "user" and isinstance(first.get("content"), list))
+        assert first["role"] == "user"
+        assert isinstance(first["content"], str)
+
+    def test_trim_never_starts_with_assistant(self, tmp_path: Path):
+        """Trimmed history should never start with an assistant message."""
+        mgr = SessionManager(sessions_dir=str(tmp_path), max_history=3)
+        session = mgr.get_or_create("cli")
+        session.messages = _tool_call_conversation()
+        mgr._save(session)
+
+        loaded = mgr.get_or_create("cli")
+        if loaded.messages:
+            assert loaded.messages[0]["role"] == "user"
+
+    def test_no_trimming_when_under_limit(self, tmp_path: Path):
+        """Messages under max_history should not be modified."""
+        mgr = SessionManager(sessions_dir=str(tmp_path), max_history=50)
+        session = mgr.get_or_create("cli")
+        session.messages = _tool_call_conversation()
+        mgr._save(session)
+
+        loaded = mgr.get_or_create("cli")
+        assert len(loaded.messages) == 10
+
+    def test_trim_preserves_complete_tool_pairs(self, tmp_path: Path):
+        """After trimming, every tool_use should have a matching tool_result."""
+        mgr = SessionManager(sessions_dir=str(tmp_path), max_history=7)
+        session = mgr.get_or_create("cli")
+        session.messages = _tool_call_conversation()
+        mgr._save(session)
+
+        loaded = mgr.get_or_create("cli")
+        # Collect tool_use IDs and tool_result IDs
+        tool_use_ids = set()
+        tool_result_ids = set()
+        for msg in loaded.messages:
+            content = msg.get("content", [])
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict):
+                        if block.get("type") == "tool_use":
+                            tool_use_ids.add(block["id"])
+                        elif block.get("type") == "tool_result":
+                            tool_result_ids.add(block["tool_use_id"])
+        # Every tool_use should have a matching result
+        assert tool_use_ids == tool_result_ids
+
+    def test_consecutive_tool_calls(self, tmp_path: Path):
+        """Multiple consecutive tool calls should be kept as complete pairs."""
+        mgr = SessionManager(sessions_dir=str(tmp_path), max_history=4)
+        messages = [
+            {"role": "user", "content": "Do two things"},
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "a", "name": "tool_a", "input": {}},
+                {"type": "tool_use", "id": "b", "name": "tool_b", "input": {}},
+            ]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "a", "content": "result_a"},
+                {"type": "tool_result", "tool_use_id": "b", "content": "result_b"},
+            ]},
+            {"role": "assistant", "content": [{"type": "text", "text": "Done!"}]},
+            {"role": "user", "content": "Great"},
+            {"role": "assistant", "content": [{"type": "text", "text": "Thanks!"}]},
+        ]
+        session = mgr.get_or_create("cli")
+        session.messages = messages
+        mgr._save(session)
+
+        loaded = mgr.get_or_create("cli")
+        assert loaded.messages[0]["role"] == "user"
+        assert isinstance(loaded.messages[0]["content"], str)


### PR DESCRIPTION
## Summary
Ensure session trimming never breaks mid-tool-call by keeping complete request/response pairs.

## Changes
- Added `_trim_preserving_tool_pairs()` to find the first safe trim boundary
- Updated `_save()` and `_load()` to use the new method
- Trimmed history always starts with a user text message, never an orphaned tool_result

## Testing
6 new tests covering tool-call preservation, consecutive tool calls, and edge cases