### PR TITLE
feat: startup secrets validation (fail fast)

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -252,11 +252,19 @@ def cmd_chat(args: argparse.Namespace) -> int:
 def cmd_listen(args: argparse.Namespace) -> int:
     """Start message listener (iMessage or BlueBubbles)."""
     from taskrunner.chat import ChatServer
+    from taskrunner.startup import SecretsValidationError, validate_secrets
 
     try:
         agent_def = _load_agent_def(args)
     except FileNotFoundError:
         print(f"Error: Agent config not found at {args.agent_config}", file=sys.stderr)
+        return 1
+
+    # Validate secrets before starting
+    try:
+        validate_secrets(agent_def)
+    except SecretsValidationError as e:
+        print(f"Error: {e}", file=sys.stderr)
         return 1
 
     # Load LLM secrets early
@@ -309,11 +317,19 @@ def cmd_serve(args: argparse.Namespace) -> int:
     import threading
 
     from taskrunner.chat import ChatServer
+    from taskrunner.startup import SecretsValidationError, validate_secrets
 
     try:
         agent_def = _load_agent_def(args)
     except FileNotFoundError:
         print(f"Error: Agent config not found at {args.agent_config}", file=sys.stderr)
+        return 1
+
+    # Validate secrets before starting
+    try:
+        validate_secrets(agent_def)
+    except SecretsValidationError as e:
+        print(f"Error: {e}", file=sys.stderr)
         return 1
 
     # Load LLM secrets early

--- a/taskrunner/startup.py
+++ b/taskrunner/startup.py
@@ -1,0 +1,70 @@
+"""Startup validation — fail fast if secrets or config are broken."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from taskrunner.secrets import decrypt_env_file
+
+logger = logging.getLogger(__name__)
+
+
+class SecretsValidationError(RuntimeError):
+    """Raised when startup secrets validation fails."""
+
+
+def validate_secrets(agent_def) -> None:
+    """Verify all referenced .enc secret files exist and are decryptable.
+
+    Checks:
+    - agent_def.llm.secrets
+    - Each tool's secrets in agent_def.tools
+
+    Raises SecretsValidationError with a clear message on failure.
+    """
+    errors: list[str] = []
+
+    # Collect all secret paths
+    secrets_paths: list[tuple[str, str]] = []  # (label, path)
+
+    if agent_def.llm.secrets:
+        secrets_paths.append(("llm.secrets", agent_def.llm.secrets))
+
+    for tool_name, tool_cfg in agent_def.tools.items():
+        if tool_cfg.secrets:
+            secrets_paths.append((f"tools.{tool_name}.secrets", tool_cfg.secrets))
+
+    if not secrets_paths:
+        logger.debug("No secrets files referenced, skipping validation")
+        return
+
+    # Check age identity file exists
+    identity_path = os.environ.get(
+        "AGE_IDENTITY_FILE",
+        str(Path.home() / ".age" / "key.txt"),
+    )
+    if not Path(identity_path).exists():
+        errors.append(f"Age identity file not found: {identity_path}")
+
+    # Check each secrets file
+    for label, path in secrets_paths:
+        p = Path(path)
+        if not p.exists():
+            errors.append(f"{label}: file not found: {path}")
+            continue
+
+        # Try to decrypt
+        if not errors:  # Only try if identity exists
+            try:
+                decrypt_env_file(path)
+                logger.debug("Validated %s: %s ✓", label, path)
+            except Exception as e:
+                errors.append(f"{label}: failed to decrypt {path}: {e}")
+
+    if errors:
+        msg = "Startup secrets validation failed:\n" + "\n".join(f"  • {e}" for e in errors)
+        raise SecretsValidationError(msg)
+
+    logger.info("All %d secret file(s) validated successfully", len(secrets_paths))

--- a/tests/test_startup_validation.py
+++ b/tests/test_startup_validation.py
@@ -1,0 +1,71 @@
+"""Tests for startup secrets validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from taskrunner.startup import SecretsValidationError, validate_secrets
+
+
+def _make_agent_def(llm_secrets=None, tools=None):
+    agent = MagicMock()
+    agent.llm.secrets = llm_secrets
+    agent.tools = tools or {}
+    return agent
+
+
+class TestValidateSecrets:
+    def test_no_secrets_passes(self):
+        """No secrets referenced should pass silently."""
+        agent = _make_agent_def()
+        validate_secrets(agent)  # should not raise
+
+    def test_missing_enc_file_raises(self, tmp_path: Path):
+        agent = _make_agent_def(llm_secrets=str(tmp_path / "nonexistent.enc"))
+        with pytest.raises(SecretsValidationError, match="file not found"):
+            validate_secrets(agent)
+
+    def test_missing_identity_file_raises(self, tmp_path: Path, monkeypatch):
+        # Create a dummy .enc file
+        enc = tmp_path / "secrets.enc"
+        enc.write_text("dummy")
+        monkeypatch.setenv("AGE_IDENTITY_FILE", str(tmp_path / "no-key.txt"))
+        agent = _make_agent_def(llm_secrets=str(enc))
+        with pytest.raises(SecretsValidationError, match="identity file not found"):
+            validate_secrets(agent)
+
+    def test_tool_secrets_validated(self, tmp_path: Path):
+        tool = MagicMock()
+        tool.secrets = str(tmp_path / "tool_secrets.enc")
+        agent = _make_agent_def(tools={"my_tool": tool})
+        with pytest.raises(SecretsValidationError, match="tools.my_tool.secrets"):
+            validate_secrets(agent)
+
+    @patch("taskrunner.startup.decrypt_env_file")
+    def test_valid_secrets_passes(self, mock_decrypt, tmp_path: Path, monkeypatch):
+        enc = tmp_path / "secrets.enc"
+        enc.write_text("encrypted data")
+        key = tmp_path / "key.txt"
+        key.write_text("AGE-SECRET-KEY-fake")
+        monkeypatch.setenv("AGE_IDENTITY_FILE", str(key))
+        mock_decrypt.return_value = {"API_KEY": "test"}
+
+        agent = _make_agent_def(llm_secrets=str(enc))
+        validate_secrets(agent)  # should not raise
+        mock_decrypt.assert_called_once_with(str(enc))
+
+    @patch("taskrunner.startup.decrypt_env_file")
+    def test_decrypt_failure_raises(self, mock_decrypt, tmp_path: Path, monkeypatch):
+        enc = tmp_path / "secrets.enc"
+        enc.write_text("bad data")
+        key = tmp_path / "key.txt"
+        key.write_text("AGE-SECRET-KEY-fake")
+        monkeypatch.setenv("AGE_IDENTITY_FILE", str(key))
+        mock_decrypt.side_effect = RuntimeError("decryption failed")
+
+        agent = _make_agent_def(llm_secrets=str(enc))
+        with pytest.raises(SecretsValidationError, match="failed to decrypt"):
+            validate_secrets(agent)


### PR DESCRIPTION
## Summary
Verify all referenced `.enc` secret files exist and are decryptable at startup, before starting the listener or scheduler.

## Changes
- New `taskrunner/startup.py` with `validate_secrets()` and `SecretsValidationError`
- Checks LLM secrets and all tool secrets
- Validates age identity file exists
- Wired into `cmd_serve` and `cmd_listen` for fail-fast behavior
- Clear error messages listing all failures

## Testing
6 new tests covering missing files, identity issues, decryption failures, and valid paths