### PR TITLE
fix: rename test_fetcher_logging → test_executor_logging

### DIFF
--- a/tests/test_executor_logging.py
+++ b/tests/test_executor_logging.py
@@ -1,4 +1,4 @@
-"""Tests for fetcher container logging and error propagation."""
+"""Tests for executor container logging and error propagation."""
 
 from __future__ import annotations
 
@@ -7,15 +7,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from taskrunner.models import FetcherConfig
+from taskrunner.models import ExecutorConfig
 
 
-class TestRunFetcherContainer:
-    """Test _run_fetcher_container error handling and logging."""
+class TestRunExecutorContainer:
+    """Test _run_executor_container error handling and logging."""
 
     @pytest.fixture
-    def config(self) -> FetcherConfig:
-        return FetcherConfig(name="test_fetcher", args={"key": "value"}, timeout=30)
+    def config(self) -> ExecutorConfig:
+        return ExecutorConfig(name="test_executor", args={"key": "value"}, timeout=30)
 
     @patch("taskrunner.orchestrator._ensure_image")
     @patch("taskrunner.orchestrator.subprocess.run")
@@ -24,7 +24,7 @@ class TestRunFetcherContainer:
         self, mock_decrypt, mock_run, mock_ensure, config, caplog
     ):
         """Stderr on success should be logged at DEBUG level."""
-        from taskrunner.orchestrator import _run_fetcher_container
+        from taskrunner.orchestrator import _run_executor_container
 
         mock_run.return_value = MagicMock(
             stdout="result data\n",
@@ -34,7 +34,7 @@ class TestRunFetcherContainer:
 
         import logging
         with caplog.at_level(logging.DEBUG):
-            result = _run_fetcher_container(config)
+            result = _run_executor_container(config)
 
         assert result == "result data"
         assert "some debug output" in caplog.text
@@ -46,7 +46,7 @@ class TestRunFetcherContainer:
         self, mock_decrypt, mock_run, mock_ensure, config
     ):
         """Non-zero exit should raise RuntimeError with stderr content."""
-        from taskrunner.orchestrator import _run_fetcher_container
+        from taskrunner.orchestrator import _run_executor_container
 
         mock_run.return_value = MagicMock(
             stdout="",
@@ -55,7 +55,7 @@ class TestRunFetcherContainer:
         )
 
         with pytest.raises(RuntimeError, match="No module named"):
-            _run_fetcher_container(config)
+            _run_executor_container(config)
 
     @patch("taskrunner.orchestrator._ensure_image")
     @patch("taskrunner.orchestrator.subprocess.run")
@@ -64,7 +64,7 @@ class TestRunFetcherContainer:
         self, mock_decrypt, mock_run, mock_ensure, config
     ):
         """Non-zero exit with empty stderr should still include exit code."""
-        from taskrunner.orchestrator import _run_fetcher_container
+        from taskrunner.orchestrator import _run_executor_container
 
         mock_run.return_value = MagicMock(
             stdout="",
@@ -73,7 +73,7 @@ class TestRunFetcherContainer:
         )
 
         with pytest.raises(RuntimeError, match="exit code 137"):
-            _run_fetcher_container(config)
+            _run_executor_container(config)
 
     @patch("taskrunner.orchestrator._ensure_image")
     @patch("taskrunner.orchestrator.subprocess.run")
@@ -81,15 +81,15 @@ class TestRunFetcherContainer:
     def test_timeout_raises_runtime_error(
         self, mock_decrypt, mock_run, mock_ensure, config
     ):
-        """Timeout should raise RuntimeError with fetcher name and timeout."""
-        from taskrunner.orchestrator import _run_fetcher_container
+        """Timeout should raise RuntimeError with executor name and timeout."""
+        from taskrunner.orchestrator import _run_executor_container
 
         mock_run.side_effect = subprocess.TimeoutExpired(
             cmd=["docker", "run"], timeout=30, stderr="partial output"
         )
 
         with pytest.raises(RuntimeError, match="timed out after 30s"):
-            _run_fetcher_container(config)
+            _run_executor_container(config)
 
     @patch("taskrunner.orchestrator._ensure_image")
     @patch("taskrunner.orchestrator.subprocess.run")
@@ -98,12 +98,12 @@ class TestRunFetcherContainer:
         self, mock_decrypt, mock_run, mock_ensure
     ):
         """Timeout should use config.timeout, not hardcoded 60."""
-        from taskrunner.orchestrator import _run_fetcher_container
+        from taskrunner.orchestrator import _run_executor_container
 
-        config = FetcherConfig(name="slow_fetcher", timeout=120)
+        config = ExecutorConfig(name="slow_executor", timeout=120)
         mock_run.return_value = MagicMock(stdout="ok", stderr="", returncode=0)
 
-        _run_fetcher_container(config)
+        _run_executor_container(config)
 
         # Verify timeout passed to subprocess.run
         call_kwargs = mock_run.call_args
@@ -117,13 +117,13 @@ class TestRunFetcherContainer:
     ):
         """Request ID should be injected as CREEL_REQUEST_ID env var."""
         from taskrunner.log import request_id_var
-        from taskrunner.orchestrator import _run_fetcher_container
+        from taskrunner.orchestrator import _run_executor_container
 
         token = request_id_var.set("abc12345")
         mock_run.return_value = MagicMock(stdout="ok", stderr="", returncode=0)
 
         try:
-            _run_fetcher_container(config)
+            _run_executor_container(config)
         finally:
             request_id_var.reset(token)
 
@@ -138,7 +138,7 @@ class TestRunFetcherContainer:
         self, mock_decrypt, mock_run, mock_ensure, config
     ):
         """Very long stderr should be truncated in the error message."""
-        from taskrunner.orchestrator import _run_fetcher_container
+        from taskrunner.orchestrator import _run_executor_container
 
         long_stderr = "x" * 1000
         mock_run.return_value = MagicMock(
@@ -148,18 +148,18 @@ class TestRunFetcherContainer:
         )
 
         with pytest.raises(RuntimeError) as exc_info:
-            _run_fetcher_container(config)
+            _run_executor_container(config)
         # Error detail truncated to 500 chars
         assert len(str(exc_info.value)) < 600
 
 
-class TestFetcherConfigTimeout:
+class TestExecutorConfigTimeout:
     def test_default_timeout(self):
-        config = FetcherConfig(name="test")
+        config = ExecutorConfig(name="test")
         assert config.timeout == 60
 
     def test_custom_timeout(self):
-        config = FetcherConfig(name="test", timeout=300)
+        config = ExecutorConfig(name="test", timeout=300)
         assert config.timeout == 300
 
 
@@ -176,10 +176,10 @@ class TestEnsureImage:
             MagicMock(returncode=1, stderr="Step 3/5 : RUN pip install\nERROR: Could not find", stdout=""),  # build
         ]
 
-        dockerfile = tmp_path / "fetchers" / "test" / "Dockerfile"
+        dockerfile = tmp_path / "executors" / "test" / "Dockerfile"
         dockerfile.parent.mkdir(parents=True)
         dockerfile.write_text("FROM python:3.11")
 
         with patch("taskrunner.orchestrator.Path", side_effect=lambda x: tmp_path / x if not str(x).startswith("/") else x):
             with pytest.raises(RuntimeError, match="Could not find"):
-                _ensure_image("fetcher-test:latest")
+                _ensure_image("executor-test:latest")


### PR DESCRIPTION
Missed in the fetcher→executor rename (PR #8). CI fails because `test_fetcher_logging.py` imports `FetcherConfig` which no longer exists. Renames file and updates all references.