### PR TITLE
fix: resolve 9 CI test failures on main

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -31,7 +31,7 @@ def valid_task_yaml(tmp_path: Path) -> Path:
     task = {
         "name": "test_task",
         "schedule": "0 7 * * *",
-        "fetch": {
+        "executors": {
             "weather": {
                 "args": {"location": "denver"},
             }
@@ -65,7 +65,7 @@ def test_invalid_cron_schedule(tmp_path: Path) -> None:
     task = {
         "name": "bad_cron",
         "schedule": "not a cron",
-        "fetch": {},
+        "executors": {},
         "prompt": "test",
         "output": {"type": "stdout", "to": ""},
     }
@@ -79,7 +79,7 @@ def test_invalid_output_type(tmp_path: Path) -> None:
     task = {
         "name": "bad_output",
         "schedule": "0 7 * * *",
-        "fetch": {},
+        "executors": {},
         "prompt": "test",
         "output": {"type": "telegram", "to": "someone"},
     }
@@ -93,7 +93,7 @@ def test_default_llm_config(tmp_path: Path) -> None:
     task = {
         "name": "defaults",
         "schedule": "0 7 * * *",
-        "fetch": {},
+        "executors": {},
         "prompt": "test",
         "output": {"type": "stdout", "to": ""},
     }
@@ -125,7 +125,7 @@ def test_multiple_executors(tmp_path: Path) -> None:
     task = {
         "name": "multi_fetch",
         "schedule": "0 7 * * *",
-        "fetch": {
+        "executors": {
             "weather": {"args": {"location": "sf"}},
             "calendar": {
                 "secrets": "secrets/gcal.env.enc",
@@ -138,9 +138,9 @@ def test_multiple_executors(tmp_path: Path) -> None:
     path = tmp_path / "multi.yaml"
     path.write_text(yaml.dump(task))
     loaded = load_task(path)
-    assert len(loaded.fetch) == 2
-    assert "weather" in loaded.fetch
-    assert "calendar" in loaded.fetch
+    assert len(loaded.executors) == 2
+    assert "weather" in loaded.executors
+    assert "calendar" in loaded.executors
 
 
 # --- Tool / Agent model tests ---
@@ -191,7 +191,7 @@ def test_task_definition_mode_default(tmp_path: Path) -> None:
     task = {
         "name": "simple_task",
         "schedule": "0 7 * * *",
-        "fetch": {},
+        "executors": {},
         "prompt": "test",
         "output": {"type": "stdout", "to": ""},
     }
@@ -207,7 +207,7 @@ def test_task_definition_agent_mode(tmp_path: Path) -> None:
         "name": "agent_task",
         "schedule": "0 8 * * *",
         "mode": "agent",
-        "fetch": {},
+        "executors": {},
         "prompt": "Triage emails",
         "output": {"type": "stdout", "to": ""},
         "tools": {
@@ -235,7 +235,7 @@ def test_invalid_mode(tmp_path: Path) -> None:
     task = {
         "name": "bad_mode",
         "schedule": "0 7 * * *",
-        "fetch": {},
+        "executors": {},
         "prompt": "test",
         "output": {"type": "stdout", "to": ""},
         "mode": "invalid",

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -16,7 +16,7 @@ def _make_task(tmp_path: Path, **overrides) -> Path:
     task = {
         "name": "test_task",
         "schedule": "0 7 * * *",
-        "fetch": {
+        "executors": {
             "weather": {
                 "args": {"location": "denver"},
             }
@@ -76,7 +76,7 @@ def test_gmail_executor_through_orchestrator(tmp_path: Path) -> None:
     task = {
         "name": "gmail_test",
         "schedule": "0 8 * * *",
-        "fetch": {
+        "executors": {
             "gmail_readonly": {
                 "args": {"query": "is:unread", "max_results": "5", "full_body": "false"},
             }
@@ -89,7 +89,7 @@ def test_gmail_executor_through_orchestrator(tmp_path: Path) -> None:
     path.write_text(yaml.dump(task))
 
     with (
-        patch("taskrunner.orchestrator._fetch_gmail_readonly_inline") as mock_gmail,
+        patch("taskrunner.orchestrator._exec_gmail_readonly_inline") as mock_gmail,
         patch("taskrunner.orchestrator.run_llm") as mock_llm,
         patch("taskrunner.orchestrator.send_output"),
     ):

--- a/tests/test_review_approval.py
+++ b/tests/test_review_approval.py
@@ -93,6 +93,9 @@ class FakeGuardian:
     def validate_action(self, tool_name, tool_input):
         return ActionDecision(verdict=self._verdict, tool_name=tool_name, reason=self._reason)
 
+    def log_action_outcome(self, tool_name, stage, outcome):
+        pass
+
 
 class FakeToolUse:
     type = "tool_use"
@@ -175,7 +178,13 @@ def _make_chat_server(tmp_path, guardian=None, imessage_channel=None):
     agent_def.session.max_history = 10
     agent_def.guardian = None
     agent_def.channels.imessage = None
-    agent_def.system_prompt = "You are a test agent. Date: {date}"
+    agent_def.system_prompt = "You are a test agent."
+    agent_def.system_prompt_file = None
+    agent_def.workspace.path = str(tmp_path / "workspace")
+    agent_def.workspace.timezone = "UTC"
+    agent_def.workspace.memory_days = 2
+    agent_def.workspace.memory_max_chars = 1000
+    agent_def.workspace.max_chars_per_file = 500
     agent_def.llm.secrets = None
     agent_def.tools = {"send_email": MagicMock()}
 
@@ -184,6 +193,8 @@ def _make_chat_server(tmp_path, guardian=None, imessage_channel=None):
     server._use_containers = False
     server._imessage_channel = imessage_channel
     server._guardian = guardian
+    server._confirm_fn = None
+    server._memory = None
     server._approval_queue = ApprovalQueue(approvals_dir=str(tmp_path / "approvals"))
 
     from taskrunner.session import SessionManager


### PR DESCRIPTION
Stale fetcher→executor references and missing mock attributes from recent merges:

- **test_models**: `fetch` → `executors` in task YAML fixtures
- **test_orchestrator**: `fetch` → `executors`, `_fetch_gmail_readonly_inline` → `_exec_gmail_readonly_inline`
- **test_review_approval**: add `log_action_outcome` to FakeGuardian, add `_memory`/`_confirm_fn` to ChatServer mock, add workspace config