### PR TITLE
Move Channel ABC out of __init__.py

### DIFF
--- a/taskrunner/channels/__init__.py
+++ b/taskrunner/channels/__init__.py
@@ -1,28 +1,5 @@
 """Channel interfaces for agent communication."""
 
-from __future__ import annotations
+from taskrunner.channels.base import Channel
 
-from abc import ABC, abstractmethod
-from typing import Callable
-
-
-class Channel(ABC):
-    """Base class for communication channels."""
-
-    _stop_requested: bool = False
-
-    @abstractmethod
-    def listen(self, callback: Callable[[str, str], str]) -> None:
-        """Listen for incoming messages.
-
-        Args:
-            callback: Function that takes (sender_id, text) and returns response text.
-        """
-
-    @abstractmethod
-    def send(self, recipient: str, text: str) -> None:
-        """Send a message to a recipient."""
-
-    def stop(self) -> None:
-        """Request the channel to stop listening."""
-        self._stop_requested = True
+__all__ = ["Channel"]

--- a/taskrunner/channels/base.py
+++ b/taskrunner/channels/base.py
@@ -1,0 +1,28 @@
+"""Channel interfaces for agent communication."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Callable
+
+
+class Channel(ABC):
+    """Base class for communication channels."""
+
+    _stop_requested: bool = False
+
+    @abstractmethod
+    def listen(self, callback: Callable[[str, str], str]) -> None:
+        """Listen for incoming messages.
+
+        Args:
+            callback: Function that takes (sender_id, text) and returns response text.
+        """
+
+    @abstractmethod
+    def send(self, recipient: str, text: str) -> None:
+        """Send a message to a recipient."""
+
+    def stop(self) -> None:
+        """Request the channel to stop listening."""
+        self._stop_requested = True


### PR DESCRIPTION
## Summary
- Moved the `Channel` ABC class from `taskrunner/channels/__init__.py` to `taskrunner/channels/base.py`
- `__init__.py` re-exports `Channel` so all existing imports remain unchanged

## Test plan
- [x] All 181 tests pass
- [x] Verified imports from `taskrunner.channels`, `stdin`, and `imessage` modules