### PR TITLE
feat: contextual policy rules (deny_when conditions)

### DIFF
--- a/guardian/core.py
+++ b/guardian/core.py
@@ -168,7 +168,7 @@ class Guardian:
                 reason="Policy engine disabled",
             )
 
-        decision = self._policy.evaluate(tool_name)
+        decision = self._policy.evaluate(tool_name, tool_args)
 
         if decision.verdict == ActionVerdict.REVIEW:
             logger.warning("Action flagged for review: %s — %s", tool_name, decision.reason)

--- a/guardian/policy.py
+++ b/guardian/policy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import fnmatch
 import logging
+import re
 from pathlib import Path
 
 import yaml
@@ -13,17 +14,56 @@ from guardian.types import ActionDecision, ActionVerdict
 logger = logging.getLogger(__name__)
 
 
+def _match_condition(condition: dict, tool_args: dict) -> bool:
+    """Check if a deny_when/review_when condition matches the tool args.
+
+    Condition format:
+        {"arg": "<arg_name>", "pattern": "<glob_pattern>"}
+
+    The pattern is matched using fnmatch (glob-style) against the string
+    value of the specified argument.  If the arg is missing from tool_args,
+    the condition does not match.
+    """
+    arg_name = condition.get("arg", "")
+    pattern = condition.get("pattern", "")
+
+    if not arg_name or not pattern:
+        return False
+
+    value = tool_args.get(arg_name)
+    if value is None:
+        return False
+
+    return fnmatch.fnmatch(str(value), pattern)
+
+
 class PolicyEngine:
     """Evaluates tool actions against allow/review/deny rules.
 
-    Evaluation order: deny → review → allow (most restrictive wins).
+    Evaluation order: deny → conditional deny_when → review →
+    conditional review_when → allow (most restrictive wins).
     Unknown tools default to ``review``.
+
+    Conditional rules (``deny_when``, ``review_when``) match on tool
+    input arguments::
+
+        deny_when:
+          - tool: send_email
+            arg: to
+            pattern: "*@external.com"
+
+        review_when:
+          - tool: upload_*
+            arg: visibility
+            pattern: "public"
     """
 
     def __init__(self, policy_file: str | Path) -> None:
         self._deny: list[str] = []
         self._review: list[str] = []
         self._allow: list[str] = []
+        self._deny_when: list[dict] = []
+        self._review_when: list[dict] = []
         self._load(Path(policy_file))
 
     def _load(self, path: Path) -> None:
@@ -37,19 +77,26 @@ class PolicyEngine:
         self._deny = data.get("deny", [])
         self._review = data.get("review", [])
         self._allow = data.get("allow", [])
+        self._deny_when = data.get("deny_when", [])
+        self._review_when = data.get("review_when", [])
 
         logger.info(
-            "Loaded policy: %d deny, %d review, %d allow rules",
+            "Loaded policy: %d deny, %d review, %d allow, %d deny_when, %d review_when rules",
             len(self._deny),
             len(self._review),
             len(self._allow),
+            len(self._deny_when),
+            len(self._review_when),
         )
 
-    def evaluate(self, tool_name: str) -> ActionDecision:
-        """Evaluate a tool name against the loaded policy rules.
+    def evaluate(self, tool_name: str, tool_args: dict | None = None) -> ActionDecision:
+        """Evaluate a tool name (and optionally args) against the loaded policy rules.
 
         Returns an ActionDecision with the verdict and matched rule.
         """
+        if tool_args is None:
+            tool_args = {}
+
         # Check deny first (most restrictive)
         for pattern in self._deny:
             if fnmatch.fnmatch(tool_name, pattern):
@@ -60,6 +107,18 @@ class PolicyEngine:
                     reason=f"Tool '{tool_name}' denied by policy rule '{pattern}'",
                 )
 
+        # Conditional deny_when rules
+        for rule in self._deny_when:
+            tool_pattern = rule.get("tool", "")
+            if fnmatch.fnmatch(tool_name, tool_pattern) and _match_condition(rule, tool_args):
+                rule_desc = f"deny_when:{tool_pattern}:{rule.get('arg')}={rule.get('pattern')}"
+                return ActionDecision(
+                    verdict=ActionVerdict.DENY,
+                    tool_name=tool_name,
+                    matched_rule=rule_desc,
+                    reason=f"Tool '{tool_name}' denied by conditional rule (arg '{rule.get('arg')}' matches '{rule.get('pattern')}')",
+                )
+
         # Then review
         for pattern in self._review:
             if fnmatch.fnmatch(tool_name, pattern):
@@ -68,6 +127,18 @@ class PolicyEngine:
                     tool_name=tool_name,
                     matched_rule=pattern,
                     reason=f"Tool '{tool_name}' flagged for review by rule '{pattern}'",
+                )
+
+        # Conditional review_when rules
+        for rule in self._review_when:
+            tool_pattern = rule.get("tool", "")
+            if fnmatch.fnmatch(tool_name, tool_pattern) and _match_condition(rule, tool_args):
+                rule_desc = f"review_when:{tool_pattern}:{rule.get('arg')}={rule.get('pattern')}"
+                return ActionDecision(
+                    verdict=ActionVerdict.REVIEW,
+                    tool_name=tool_name,
+                    matched_rule=rule_desc,
+                    reason=f"Tool '{tool_name}' flagged for review by conditional rule (arg '{rule.get('arg')}' matches '{rule.get('pattern')}')",
                 )
 
         # Then allow

--- a/tests/test_contextual_policies.py
+++ b/tests/test_contextual_policies.py
@@ -1,0 +1,148 @@
+"""Tests for contextual policy rules (deny_when / review_when)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from guardian.policy import PolicyEngine, _match_condition
+from guardian.types import ActionVerdict
+
+
+class TestMatchCondition:
+    def test_exact_match(self) -> None:
+        assert _match_condition(
+            {"arg": "to", "pattern": "evil@hacker.com"},
+            {"to": "evil@hacker.com"},
+        )
+
+    def test_glob_match(self) -> None:
+        assert _match_condition(
+            {"arg": "to", "pattern": "*@external.com"},
+            {"to": "user@external.com"},
+        )
+
+    def test_no_match(self) -> None:
+        assert not _match_condition(
+            {"arg": "to", "pattern": "*@external.com"},
+            {"to": "user@internal.com"},
+        )
+
+    def test_missing_arg(self) -> None:
+        assert not _match_condition(
+            {"arg": "to", "pattern": "*@external.com"},
+            {"subject": "hello"},
+        )
+
+    def test_empty_condition(self) -> None:
+        assert not _match_condition({}, {"to": "test"})
+
+    def test_empty_pattern(self) -> None:
+        assert not _match_condition({"arg": "to", "pattern": ""}, {"to": "test"})
+
+    def test_non_string_value(self) -> None:
+        """Non-string values should be coerced to string."""
+        assert _match_condition(
+            {"arg": "count", "pattern": "42"},
+            {"count": 42},
+        )
+
+
+@pytest.fixture
+def contextual_policy(tmp_path: Path) -> PolicyEngine:
+    p = tmp_path / "policy.yaml"
+    p.write_text(textwrap.dedent("""\
+        allow:
+          - check_weather
+          - send_email
+
+        review:
+          - upload_*
+
+        deny:
+          - delete_*
+
+        deny_when:
+          - tool: send_email
+            arg: to
+            pattern: "*@external.com"
+          - tool: send_email
+            arg: to
+            pattern: "*@competitor.com"
+
+        review_when:
+          - tool: upload_*
+            arg: visibility
+            pattern: "public"
+    """))
+    return PolicyEngine(p)
+
+
+class TestDenyWhen:
+    def test_deny_when_matches(self, contextual_policy: PolicyEngine) -> None:
+        decision = contextual_policy.evaluate("send_email", {"to": "spy@external.com"})
+        assert decision.verdict == ActionVerdict.DENY
+        assert "deny_when" in decision.matched_rule
+        assert "external.com" in decision.reason
+
+    def test_deny_when_second_rule(self, contextual_policy: PolicyEngine) -> None:
+        decision = contextual_policy.evaluate("send_email", {"to": "info@competitor.com"})
+        assert decision.verdict == ActionVerdict.DENY
+
+    def test_deny_when_no_match_falls_through(self, contextual_policy: PolicyEngine) -> None:
+        decision = contextual_policy.evaluate("send_email", {"to": "friend@internal.com"})
+        assert decision.verdict == ActionVerdict.ALLOW
+
+    def test_deny_when_missing_arg(self, contextual_policy: PolicyEngine) -> None:
+        decision = contextual_policy.evaluate("send_email", {"subject": "hello"})
+        assert decision.verdict == ActionVerdict.ALLOW
+
+    def test_deny_when_no_args(self, contextual_policy: PolicyEngine) -> None:
+        decision = contextual_policy.evaluate("send_email")
+        assert decision.verdict == ActionVerdict.ALLOW
+
+    def test_deny_when_tool_no_match(self, contextual_policy: PolicyEngine) -> None:
+        """deny_when for send_email should not affect other tools."""
+        decision = contextual_policy.evaluate("check_weather", {"to": "spy@external.com"})
+        assert decision.verdict == ActionVerdict.ALLOW
+
+    def test_static_deny_still_works(self, contextual_policy: PolicyEngine) -> None:
+        decision = contextual_policy.evaluate("delete_file", {})
+        assert decision.verdict == ActionVerdict.DENY
+
+
+class TestReviewWhen:
+    def test_review_when_matches(self, contextual_policy: PolicyEngine) -> None:
+        decision = contextual_policy.evaluate("upload_doc", {"visibility": "public"})
+        # upload_* matches review statically AND review_when — review either way
+        assert decision.verdict == ActionVerdict.REVIEW
+
+    def test_review_when_no_match(self, contextual_policy: PolicyEngine) -> None:
+        decision = contextual_policy.evaluate("upload_doc", {"visibility": "private"})
+        # Still matches static review for upload_*
+        assert decision.verdict == ActionVerdict.REVIEW
+
+
+class TestBackwardCompatibility:
+    def test_evaluate_without_args(self, contextual_policy: PolicyEngine) -> None:
+        """Calling evaluate with just tool_name should still work."""
+        decision = contextual_policy.evaluate("check_weather")
+        assert decision.verdict == ActionVerdict.ALLOW
+
+    def test_old_style_policy_still_works(self, tmp_path: Path) -> None:
+        """Policy without deny_when/review_when should work as before."""
+        p = tmp_path / "policy.yaml"
+        p.write_text(textwrap.dedent("""\
+            allow:
+              - check_weather
+            review:
+              - send_*
+            deny:
+              - delete_*
+        """))
+        engine = PolicyEngine(p)
+        assert engine.evaluate("check_weather").verdict == ActionVerdict.ALLOW
+        assert engine.evaluate("send_email").verdict == ActionVerdict.REVIEW
+        assert engine.evaluate("delete_all").verdict == ActionVerdict.DENY


### PR DESCRIPTION
Extend policy engine to support conditional rules matching on tool arguments.

- Add deny_when and review_when conditional rules
- Rules can match on tool input arguments using glob patterns
- Backward compatible — existing policies work unchanged
- Full test coverage

Phase 2 Security task.