### PR TITLE
feat: per-tool review overrides (auto_approve)

### DIFF
--- a/guardian/policy.py
+++ b/guardian/policy.py
@@ -64,6 +64,7 @@ class PolicyEngine:
         self._allow: list[str] = []
         self._deny_when: list[dict] = []
         self._review_when: list[dict] = []
+        self._auto_approve: list[str] = []
         self._load(Path(policy_file))
 
     def _load(self, path: Path) -> None:
@@ -79,14 +80,16 @@ class PolicyEngine:
         self._allow = data.get("allow", [])
         self._deny_when = data.get("deny_when", [])
         self._review_when = data.get("review_when", [])
+        self._auto_approve = data.get("auto_approve", [])
 
         logger.info(
-            "Loaded policy: %d deny, %d review, %d allow, %d deny_when, %d review_when rules",
+            "Loaded policy: %d deny, %d review, %d allow, %d deny_when, %d review_when, %d auto_approve rules",
             len(self._deny),
             len(self._review),
             len(self._allow),
             len(self._deny_when),
             len(self._review_when),
+            len(self._auto_approve),
         )
 
     def evaluate(self, tool_name: str, tool_args: dict | None = None) -> ActionDecision:
@@ -119,9 +122,18 @@ class PolicyEngine:
                     reason=f"Tool '{tool_name}' denied by conditional rule (arg '{rule.get('arg')}' matches '{rule.get('pattern')}')",
                 )
 
-        # Then review
+        # Then review (but check auto_approve override)
         for pattern in self._review:
             if fnmatch.fnmatch(tool_name, pattern):
+                # Check if tool has auto_approve override
+                for ap_pattern in self._auto_approve:
+                    if fnmatch.fnmatch(tool_name, ap_pattern):
+                        return ActionDecision(
+                            verdict=ActionVerdict.ALLOW,
+                            tool_name=tool_name,
+                            matched_rule=f"auto_approve:{ap_pattern}",
+                            reason=f"Tool '{tool_name}' auto-approved (matched review '{pattern}' but overridden by auto_approve '{ap_pattern}')",
+                        )
                 return ActionDecision(
                     verdict=ActionVerdict.REVIEW,
                     tool_name=tool_name,
@@ -151,7 +163,15 @@ class PolicyEngine:
                     reason=f"Tool '{tool_name}' allowed by rule '{pattern}'",
                 )
 
-        # Unknown tool — default to review
+        # Unknown tool — default to review (but check auto_approve)
+        for ap_pattern in self._auto_approve:
+            if fnmatch.fnmatch(tool_name, ap_pattern):
+                return ActionDecision(
+                    verdict=ActionVerdict.ALLOW,
+                    tool_name=tool_name,
+                    matched_rule=f"auto_approve:{ap_pattern}",
+                    reason=f"Tool '{tool_name}' auto-approved (would default to review but overridden by auto_approve '{ap_pattern}')",
+                )
         return ActionDecision(
             verdict=ActionVerdict.REVIEW,
             tool_name=tool_name,

--- a/policies/default.yaml
+++ b/policies/default.yaml
@@ -17,3 +17,8 @@ review:
 
 deny:
   - delete_*
+
+# Tools that match 'review' rules but can skip human approval
+auto_approve:
+  - mark_read
+  - react_imessage

--- a/tests/test_per_tool_review.py
+++ b/tests/test_per_tool_review.py
@@ -1,0 +1,121 @@
+"""Tests for per-tool review overrides (auto_approve)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from guardian.policy import PolicyEngine
+from guardian.types import ActionVerdict
+
+
+@pytest.fixture
+def policy_with_auto_approve(tmp_path: Path) -> PolicyEngine:
+    p = tmp_path / "policy.yaml"
+    p.write_text(textwrap.dedent("""\
+        allow:
+          - check_weather
+          - check_email
+
+        review:
+          - send_*
+          - mark_*
+          - react_*
+
+        deny:
+          - delete_*
+
+        auto_approve:
+          - mark_read
+          - react_imessage
+    """))
+    return PolicyEngine(p)
+
+
+class TestAutoApprove:
+    def test_auto_approve_skips_review(self, policy_with_auto_approve: PolicyEngine) -> None:
+        decision = policy_with_auto_approve.evaluate("mark_read")
+        assert decision.verdict == ActionVerdict.ALLOW
+        assert "auto_approve" in decision.matched_rule
+
+    def test_auto_approve_react(self, policy_with_auto_approve: PolicyEngine) -> None:
+        decision = policy_with_auto_approve.evaluate("react_imessage")
+        assert decision.verdict == ActionVerdict.ALLOW
+        assert "auto_approve" in decision.matched_rule
+
+    def test_non_auto_approve_still_review(self, policy_with_auto_approve: PolicyEngine) -> None:
+        decision = policy_with_auto_approve.evaluate("mark_unread")
+        assert decision.verdict == ActionVerdict.REVIEW
+
+    def test_send_email_still_review(self, policy_with_auto_approve: PolicyEngine) -> None:
+        decision = policy_with_auto_approve.evaluate("send_email")
+        assert decision.verdict == ActionVerdict.REVIEW
+
+    def test_deny_not_overridden(self, policy_with_auto_approve: PolicyEngine) -> None:
+        """auto_approve should NOT override deny rules."""
+        decision = policy_with_auto_approve.evaluate("delete_file")
+        assert decision.verdict == ActionVerdict.DENY
+
+    def test_allow_unaffected(self, policy_with_auto_approve: PolicyEngine) -> None:
+        decision = policy_with_auto_approve.evaluate("check_weather")
+        assert decision.verdict == ActionVerdict.ALLOW
+        assert "auto_approve" not in decision.matched_rule
+
+
+class TestAutoApproveGlob:
+    def test_glob_auto_approve(self, tmp_path: Path) -> None:
+        p = tmp_path / "policy.yaml"
+        p.write_text(textwrap.dedent("""\
+            review:
+              - mark_*
+            auto_approve:
+              - mark_*
+        """))
+        engine = PolicyEngine(p)
+        decision = engine.evaluate("mark_read")
+        assert decision.verdict == ActionVerdict.ALLOW
+        assert "auto_approve" in decision.matched_rule
+
+    def test_unknown_tool_with_auto_approve(self, tmp_path: Path) -> None:
+        p = tmp_path / "policy.yaml"
+        p.write_text(textwrap.dedent("""\
+            review:
+              - send_*
+            auto_approve:
+              - my_custom_tool
+        """))
+        engine = PolicyEngine(p)
+        # my_custom_tool is unknown (not in review/allow/deny) but in auto_approve
+        decision = engine.evaluate("my_custom_tool")
+        assert decision.verdict == ActionVerdict.ALLOW
+        assert "auto_approve" in decision.matched_rule
+
+
+class TestNoAutoApprove:
+    def test_policy_without_auto_approve(self, tmp_path: Path) -> None:
+        p = tmp_path / "policy.yaml"
+        p.write_text(textwrap.dedent("""\
+            allow:
+              - check_weather
+            review:
+              - send_*
+            deny:
+              - delete_*
+        """))
+        engine = PolicyEngine(p)
+        decision = engine.evaluate("send_email")
+        assert decision.verdict == ActionVerdict.REVIEW
+
+
+class TestDefaultPolicy:
+    def test_default_policy_auto_approve(self) -> None:
+        """Verify the default policy file has auto_approve entries."""
+        engine = PolicyEngine("policies/default.yaml")
+        # mark_read should be auto-approved
+        decision = engine.evaluate("mark_read")
+        assert decision.verdict == ActionVerdict.ALLOW
+        # send_email should still require review
+        decision = engine.evaluate("send_email")
+        assert decision.verdict == ActionVerdict.REVIEW


### PR DESCRIPTION
Allow tools to specify auto_approve in policy config to skip REVIEW.

- mark_read can auto-approve but send_email always asks
- New auto_approve list in policy.yaml schema
- Does NOT override deny rules
- Full test coverage

Phase 2 Security task.