### PR TITLE
Strengthen live container smoke coverage

### DIFF
--- a/scripts/smoke_cases.yaml
+++ b/scripts/smoke_cases.yaml
@@ -171,33 +171,32 @@ cases:
     command: ["docker", "build", "-t", "llm-runner:latest", "llm/"]
     timeout: 2400
 
-  - id: containers-2-chat-simple
+  - id: containers-2-agent-tool-call
     order: 210
     phase: containers
     tags: [containers, quick]
-    title: Containerized Chat --simple
-    handler: quick_chat
-    container_mode: true
+    title: Containerized Agent Tool Call
+    handler: container_agent_tool_call
     requires_live_docker: true
     requires_live_llm: true
-    messages:
-      - "what's the weather?"
-      - "/clear"
+    verify_token: AGENT_TOOL_CONTAINER_OK
+    attempts: 2
+    message: "Call the check_weather tool with location Denver. You must call the tool before answering. End your final response with AGENT_TOOL_CONTAINER_OK."
     line_delay_s: 2.0
     wait_before_sigint_s: 3.0
     final_timeout_s: 90
-    min_assistant_lines: 1
 
   - id: containers-3-run-task
     order: 220
     phase: containers
     tags: [containers]
-    title: Containerized Task Run (morning_briefing)
-    handler: command
+    title: Containerized Simple Task (Executor + LLM)
+    handler: container_simple_task
     requires_live_docker: true
     requires_live_llm: true
-    command: ["{python}", "runner.py", "--containers", "run", "morning_briefing"]
-    timeout: 1800
+    task_name: container_weather_smoke
+    verify_token: SIMPLE_CONTAINER_OK
+    timeout: 900
 
   - id: extras-1-session-commands
     order: 300

--- a/scripts/smoke_runner.py
+++ b/scripts/smoke_runner.py
@@ -866,6 +866,185 @@ def handle_quick_chat(case: dict[str, Any], ctx: SmokeContext) -> CaseResult:
     )
 
 
+def handle_container_simple_task(case: dict[str, Any], ctx: SmokeContext) -> CaseResult:
+    started = time.perf_counter()
+    tasks_dir = ctx.run_dir / "runtime" / "container_simple_task" / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+
+    task_name = str(case.get("task_name", "container_weather_smoke"))
+    verify_token = str(case.get("verify_token", "SIMPLE_CONTAINER_OK"))
+    location = str(case.get("location", "denver"))
+
+    task_path = tasks_dir / f"{task_name}.yaml"
+    task_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": task_name,
+                "schedule": "* * * * *",
+                "executors": {
+                    "weather": {
+                        "args": {
+                            "location": location,
+                        },
+                    },
+                },
+                "prompt": (
+                    "Weather data:\n\n"
+                    "{weather}\n\n"
+                    f"Reply in one concise sentence and include token {verify_token}."
+                ),
+                "output": {
+                    "type": "stdout",
+                    "to": "",
+                },
+                "llm": {
+                    "model": "claude-sonnet-4-20250514",
+                    "max_tokens": 180,
+                },
+            },
+            sort_keys=False,
+        )
+    )
+
+    command = [
+        ctx.python_bin,
+        "runner.py",
+        "-v",
+        "--containers",
+        "--tasks-dir",
+        str(tasks_dir),
+        "run",
+        task_name,
+    ]
+    result = _run_command(
+        command,
+        cwd=ctx.repo_root,
+        timeout=int(case.get("timeout", 900)),
+        env=os.environ.copy(),
+    )
+    output = result.output
+    ok = (
+        result.returncode == 0
+        and f"Task '{task_name}' completed." in output
+        and verify_token in output
+    )
+    detail = (
+        f"container simple task succeeded with token {verify_token}"
+        if ok
+        else "container simple task did not produce expected completion/token output"
+    )
+    log_path = _write_case_log(ctx, case["id"], _command_log_blob(result))
+    return _result(
+        case,
+        "pass" if ok else "fail",
+        time.perf_counter() - started,
+        detail,
+        log_file=log_path,
+        exit_code=result.returncode,
+    )
+
+
+def handle_container_agent_tool_call(case: dict[str, Any], ctx: SmokeContext) -> CaseResult:
+    started = time.perf_counter()
+    token = str(case.get("verify_token", "AGENT_TOOL_CONTAINER_OK"))
+    attempts = int(case.get("attempts", 2))
+    message_template = str(
+        case.get(
+            "message",
+            (
+                "Call the check_weather tool with location Denver. "
+                "You must call the tool before answering. "
+                f"End your final response with {token}."
+            ),
+        )
+    )
+
+    config_path = _build_minimal_agent_config(
+        ctx,
+        "container_agent_tool_call",
+        updates={
+            "tools": {
+                "check_weather": {
+                    "executor": "weather",
+                    "description": "Get current weather and forecast",
+                    "parameters": {
+                        "location": {
+                            "type": "string",
+                            "description": "City name or coordinates",
+                            "required": True,
+                        },
+                    },
+                },
+            },
+            "llm": {
+                "model": "claude-sonnet-4-20250514",
+                "max_tokens": 220,
+            },
+            "guardian": {
+                "enabled": False,
+            },
+        },
+    )
+
+    logs: list[str] = []
+    last_rc = 1
+    for attempt in range(1, attempts + 1):
+        command = [
+            ctx.python_bin,
+            "runner.py",
+            "-v",
+            "--containers",
+            "--agent-config",
+            str(config_path),
+            "chat",
+            "--simple",
+            "--new",
+        ]
+        lines = [message_template, "/clear"]
+        result = _spawn_with_sigint(
+            command,
+            cwd=ctx.repo_root,
+            wait_before_sigint_s=float(case.get("wait_before_sigint_s", 3.0)),
+            final_timeout_s=int(case.get("final_timeout_s", 90)),
+            stdin_lines=lines,
+            line_delay_s=float(case.get("line_delay_s", 2.0)),
+            env=os.environ.copy(),
+        )
+        last_rc = result.returncode
+        output = result.output
+        tool_marker_seen = bool(re.search(r"Executing tool check_weather", output))
+        token_seen = token in output
+        logs.append(
+            (
+                f"=== Attempt {attempt} ===\n"
+                f"tool_marker_seen={tool_marker_seen}\n"
+                f"token_seen={token_seen}\n"
+                f"{_command_log_blob(result)}\n"
+            )
+        )
+
+        if result.returncode in {0, 130} and tool_marker_seen and token_seen:
+            log_path = _write_case_log(ctx, case["id"], "\n".join(logs))
+            return _result(
+                case,
+                "pass",
+                time.perf_counter() - started,
+                f"agent container path exercised with tool call (attempt {attempt})",
+                log_file=log_path,
+                exit_code=result.returncode,
+            )
+
+    log_path = _write_case_log(ctx, case["id"], "\n".join(logs))
+    return _result(
+        case,
+        "fail",
+        time.perf_counter() - started,
+        "did not observe both tool execution marker and response token in container chat",
+        log_file=log_path,
+        exit_code=last_rc,
+    )
+
+
 def handle_cli_help(case: dict[str, Any], ctx: SmokeContext) -> CaseResult:
     started = time.perf_counter()
     commands = [
@@ -922,6 +1101,8 @@ HANDLERS: dict[str, Any] = {
     "audit_cli_runtime": handle_audit_cli_runtime,
     "onnx_export": handle_onnx_export,
     "quick_chat": handle_quick_chat,
+    "container_simple_task": handle_container_simple_task,
+    "container_agent_tool_call": handle_container_agent_tool_call,
     "cli_help": handle_cli_help,
 }
 


### PR DESCRIPTION
## Summary
- strengthen live container smoke coverage for both task mode and agent mode
- add `container_simple_task` handler to generate and run a deterministic containerized task and assert tokenized output
- add `container_agent_tool_call` handler to generate a minimal tool config, run `chat --containers`, and assert an actual tool execution marker plus response token
- update container cases in scripts/smoke_cases.yaml to use these deterministic handlers instead of relying on `morning_briefing`/non-deterministic prompts

## Why
- previous container smoke checks confirmed startup paths but did not reliably prove a real agent tool-call cycle in container mode
- this change makes container coverage explicit and repeatable

## Testing
- python3 -m py_compile scripts/smoke_runner.py
