### PR TITLE
fix: prevent session corruption from Guardian-blocked tool calls

### DIFF
--- a/src/guardian/coherence.py
+++ b/src/guardian/coherence.py
@@ -95,7 +95,16 @@ class CoherenceChecker:
                 if block.type == "text":
                     raw_text += block.text
 
-            result = json.loads(raw_text)
+            # Try to extract JSON from response — LLM sometimes wraps it in markdown
+            try:
+                result = json.loads(raw_text)
+            except json.JSONDecodeError:
+                import re
+                match = re.search(r"\{[^}]+\}", raw_text)
+                if match:
+                    result = json.loads(match.group())
+                else:
+                    raise
 
             coherent = bool(result.get("coherent", True))
             confidence = float(result.get("confidence", 0.5))

--- a/src/taskrunner/agent.py
+++ b/src/taskrunner/agent.py
@@ -176,7 +176,23 @@ def run_agent_loop(
                         # User approved — fall through to execute
                         guardian.log_action_outcome(tool_name, "review", "approved_by_user")
                     else:
-                        # No callback — return for async approval queue
+                        # No callback — inject synthetic tool_results for ALL
+                        # tool_use blocks so the session history stays valid,
+                        # then return for async approval queue.
+                        synthetic_results = []
+                        for b in tool_use_blocks:
+                            if b.id == block.id:
+                                msg = f"Action requires approval: {decision.reason}"
+                            else:
+                                msg = "Action skipped — another tool in this batch requires approval."
+                            synthetic_results.append({
+                                "type": "tool_result",
+                                "tool_use_id": b.id,
+                                "content": msg,
+                                "is_error": True,
+                            })
+                        messages.append({"role": "user", "content": synthetic_results})
+
                         return AgentResult(
                             text="This action requires approval before proceeding.",
                             turns_used=turns_used,

--- a/src/taskrunner/container_agent.py
+++ b/src/taskrunner/container_agent.py
@@ -258,7 +258,18 @@ def _handle_tool_request(
                         continue
                     guardian.log_action_outcome(tool_name, "review", "approved_by_user")
                 else:
-                    # No callback — return for async approval
+                    # No callback — inject synthetic tool_results for ALL
+                    # tool calls so session history stays valid.
+                    for call in calls:
+                        if call["id"] == tool_id:
+                            msg = f"Action requires approval: {decision.reason}"
+                        else:
+                            msg = "Action skipped — another tool in this batch requires approval."
+                        results.append({
+                            "tool_use_id": call["id"],
+                            "content": msg,
+                            "is_error": True,
+                        })
                     _pending_approval_result = AgentResult(
                         text="This action requires approval before proceeding.",
                         turns_used=0,


### PR DESCRIPTION
When Guardian REVIEW fires without a confirm callback (e.g. `creel send` mode), the agent returned early without injecting tool_result messages. This left orphaned `tool_use` blocks in session history, causing Anthropic API 400 errors on subsequent messages.

**Fix:** Inject synthetic `tool_result` (with `is_error: true`) for all tool_use blocks before returning the approval_required result. Session history stays valid even when tools are blocked.

**Also fixed:**
- Coherence check JSON parsing — now extracts JSON from markdown-wrapped LLM responses
- Applied to both inline agent (`agent.py`) and container agent (`container_agent.py`)

1010 tests passing.