### PR TITLE
fix: iMessage self-reply infinite loop

### DIFF
--- a/src/taskrunner/channels/imessage.py
+++ b/src/taskrunner/channels/imessage.py
@@ -61,9 +61,15 @@ class IMessageChannel(Channel):
                 consecutive_errors = 0  # reset on success
                 for msg in new_messages:
                     sender = msg["sender"]
+                    text = msg["text"]
+                    # Skip our own replies (iMessage to self shows as is_from_me=0)
+                    if text.startswith(MESSAGE_PREFIX):
+                        logger.debug("Skipping own message: %s", text[:40])
+                        last_rowid = max(last_rowid, msg["rowid"])
+                        continue
                     if sender in self._allowed_senders:
-                        logger.info("Message from %s: %s", sender, msg["text"][:80])
-                        response = callback(sender, msg["text"])
+                        logger.info("Message from %s: %s", sender, text[:80])
+                        response = callback(sender, text)
                         self.send(sender, response)
                     last_rowid = max(last_rowid, msg["rowid"])
             except Exception:


### PR DESCRIPTION
When the listened phone number is your own, iMessage replies from Creel show up as `is_from_me=0` in chat.db. Creel picks them up as new inbound messages → infinite loop.

Fix: skip messages starting with `MESSAGE_PREFIX` (`[safe-claw]`) in the poll loop.