### PR TITLE
Fix review integrity: results duplication, mixed-content repair

### DIFF
--- a/src/taskrunner/agent.py
+++ b/src/taskrunner/agent.py
@@ -49,7 +49,7 @@ def _extract_prior_tools(messages: list[dict]) -> list[str]:
     return prior
 
 
-def ensure_tool_call_integrity(messages: list[dict]) -> int:
+def _ensure_tool_call_integrity(messages: list[dict]) -> int:
     """Repair orphaned tool_use/tool_result sequences in-place.
 
     Anthropic requires every assistant ``tool_use`` block to be followed
@@ -98,12 +98,13 @@ def ensure_tool_call_integrity(messages: list[dict]) -> int:
                 if block.get("tool_use_id") is not None
             }
 
-            if not contains_non_tool_results:
-                missing_ids = [tool_id for tool_id in required_ids if tool_id not in present_ids]
-                if not missing_ids:
-                    i += 2
-                    continue
+            missing_ids = [tool_id for tool_id in required_ids if tool_id not in present_ids]
+            if not missing_ids:
+                i += 2
+                continue
 
+            if not contains_non_tool_results:
+                # Pure tool_result message — append missing results in-place.
                 for tool_id in missing_ids:
                     next_content.append({
                         "type": "tool_result",
@@ -117,6 +118,21 @@ def ensure_tool_call_integrity(messages: list[dict]) -> int:
                 inserted_blocks += len(missing_ids)
                 i += 2
                 continue
+
+            # Mixed content (text + tool_results) — insert a separate message
+            # with only the missing results so we don't duplicate existing ones.
+            synthetic_for_missing = [{
+                "type": "tool_result",
+                "tool_use_id": tool_id,
+                "content": (
+                    "Tool execution was blocked or interrupted before results were recorded."
+                ),
+                "is_error": True,
+            } for tool_id in missing_ids]
+            messages.insert(i + 1, {"role": "user", "content": synthetic_for_missing})
+            inserted_blocks += len(synthetic_for_missing)
+            i += 3  # skip: assistant, inserted synthetic, original next_msg
+            continue
 
         synthetic_results = [{
             "type": "tool_result",
@@ -179,7 +195,7 @@ def run_agent_loop(
     for turn in range(agent_config.max_turns):
         turns_used += 1
         logger.info("Agent turn %d/%d", turns_used, agent_config.max_turns)
-        ensure_tool_call_integrity(messages)
+        _ensure_tool_call_integrity(messages)
 
         try:
             response = call_llm(
@@ -538,7 +554,7 @@ def run_agent_loop(
     # Don't stream the forced summary — it's an internal wrap-up, not a direct
     # response, and streaming it would concatenate with the prior streamed output.
     logger.warning("Max turns (%d) reached, forcing final response", agent_config.max_turns)
-    ensure_tool_call_integrity(messages)
+    _ensure_tool_call_integrity(messages)
     try:
         response = call_llm(
             messages=messages,

--- a/src/taskrunner/container_agent.py
+++ b/src/taskrunner/container_agent.py
@@ -18,8 +18,8 @@ from guardian.types import ActionVerdict
 from taskrunner.agent import (
     AgentResult,
     PendingApproval,
+    _ensure_tool_call_integrity,
     _extract_prior_tools,
-    ensure_tool_call_integrity,
 )
 from taskrunner.models import AgentConfig, LLMConfig, ToolConfig
 from taskrunner.orchestrator import _ensure_image
@@ -53,7 +53,7 @@ def run_agent_loop_container(
     The container communicates via JSON-over-stdio. Tool execution,
     Guardian validation, and secret management all happen on the host.
     """
-    ensure_tool_call_integrity(messages)
+    _ensure_tool_call_integrity(messages)
     _ensure_image(_IMAGE)
 
     include_memory = memory_manager is not None
@@ -280,19 +280,21 @@ def _handle_tool_request(
                     # No callback — inject synthetic tool_results for ALL
                     # tool calls so session history stays valid.
                     assistant_tool_use = []
-                    for call in calls:
+                    synthetic_results = []
+                    for c in calls:
                         assistant_tool_use.append({
                             "type": "tool_use",
-                            "id": call["id"],
-                            "name": call["name"],
-                            "input": call["input"],
+                            "id": c["id"],
+                            "name": c["name"],
+                            "input": c["input"],
                         })
-                        if call["id"] == tool_id:
+                        if c["id"] == tool_id:
                             msg = f"Action requires approval: {decision.reason}"
                         else:
                             msg = "Action skipped — another tool in this batch requires approval."
-                        results.append({
-                            "tool_use_id": call["id"],
+                        synthetic_results.append({
+                            "type": "tool_result",
+                            "tool_use_id": c["id"],
                             "content": msg,
                             "is_error": True,
                         })
@@ -302,15 +304,7 @@ def _handle_tool_request(
                     messages.append({"role": "assistant", "content": assistant_tool_use})
                     messages.append({
                         "role": "user",
-                        "content": [
-                            {
-                                "type": "tool_result",
-                                "tool_use_id": r["tool_use_id"],
-                                "content": r["content"],
-                                "is_error": r["is_error"],
-                            }
-                            for r in results
-                        ],
+                        "content": synthetic_results,
                     })
                     _pending_approval_result = AgentResult(
                         text="This action requires approval before proceeding.",

--- a/tests/test_review_approval.py
+++ b/tests/test_review_approval.py
@@ -328,6 +328,35 @@ def test_orphaned_tool_use_is_repaired_before_llm_call(mock_llm):
     assert repaired, "Expected synthetic tool_result for orphaned tool_use"
 
 
+def test_partial_tool_results_repaired():
+    """When some tool_results are present but others missing, only missing ones are injected."""
+    from taskrunner.agent import _ensure_tool_call_integrity
+
+    messages = [
+        {"role": "user", "content": "do two things"},
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "tool_a", "name": "send_email", "input": {}},
+            {"type": "tool_use", "id": "tool_b", "name": "check_weather", "input": {}},
+        ]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "tool_a", "content": "sent", "is_error": False},
+        ]},
+        {"role": "user", "content": "what happened?"},
+    ]
+
+    count = _ensure_tool_call_integrity(messages)
+
+    assert count == 1
+    # The existing user tool_result message should now have 2 entries
+    tool_result_msg = messages[2]
+    assert len(tool_result_msg["content"]) == 2
+    ids = {b["tool_use_id"] for b in tool_result_msg["content"]}
+    assert ids == {"tool_a", "tool_b"}
+    # The injected one should be an error
+    injected = [b for b in tool_result_msg["content"] if b["tool_use_id"] == "tool_b"]
+    assert injected[0]["is_error"] is True
+
+
 def test_chat_approval_sends_imessage(tmp_path):
     """Approval request sends iMessage when channel is available."""
     mock_channel = MagicMock()


### PR DESCRIPTION
## Summary
Followup fixes for #84 (Guardian review session integrity):

- **Fix results duplication in container_agent** — the review-no-callback branch was appending synthetic results to the accumulated `results` list, causing duplicate `tool_use_id` entries when earlier tools had already been processed. Uses a separate `synthetic_results` list now.
- **Fix mixed-content edge case in `_ensure_tool_call_integrity`** — when a user message contained both text and `tool_result` blocks, the repair code inserted synthetics for *all* required IDs instead of only the missing ones. Now computes `missing_ids` first in all branches.
- **Rename `ensure_tool_call_integrity` → `_ensure_tool_call_integrity`** — internal utility, not part of the public API.
- **Fix variable shadowing** — inner `for call in calls:` renamed to `for c in calls:`.
- **Add `"type": "tool_result"`** to synthetic result dicts in container_agent for API consistency.
- **Add test** for partially matched tool_results repair path (2 tool_uses, 1 existing tool_result).

## Test plan
- [x] All 1151 tests pass (`pytest tests/ -v`)
- [ ] Verify container mode review flow still works end-to-end