### PR TITLE
fix: use executor-specific directory as Docker build context

### DIFF
--- a/src/executors/apple_notes/Dockerfile
+++ b/src/executors/apple_notes/Dockerfile
@@ -5,9 +5,9 @@ RUN useradd -m -u 1000 executor
 USER executor
 WORKDIR /app
 
-COPY --chown=executor:executor requirements.txt .
+COPY --chown=executor:executor apple_notes/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --user -r requirements.txt
 
-COPY --chown=executor:executor executor.py .
+COPY --chown=executor:executor apple_notes/executor.py ./executor.py
 
 ENTRYPOINT ["python", "executor.py"]

--- a/src/executors/apple_reminders/Dockerfile
+++ b/src/executors/apple_reminders/Dockerfile
@@ -5,9 +5,9 @@ RUN useradd -m -u 1000 executor
 USER executor
 WORKDIR /app
 
-COPY --chown=executor:executor requirements.txt .
+COPY --chown=executor:executor apple_reminders/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --user -r requirements.txt
 
-COPY --chown=executor:executor executor.py .
+COPY --chown=executor:executor apple_reminders/executor.py ./executor.py
 
 ENTRYPOINT ["python", "executor.py"]

--- a/src/executors/browser/Dockerfile
+++ b/src/executors/browser/Dockerfile
@@ -5,9 +5,9 @@ RUN useradd -m -u 1000 executor
 USER executor
 WORKDIR /app
 
-COPY --chown=executor:executor requirements.txt .
+COPY --chown=executor:executor browser/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --user -r requirements.txt
 
-COPY --chown=executor:executor executor.py .
+COPY --chown=executor:executor browser/executor.py ./executor.py
 
 ENTRYPOINT ["python", "executor.py"]

--- a/src/executors/notion/Dockerfile
+++ b/src/executors/notion/Dockerfile
@@ -5,9 +5,9 @@ RUN useradd -m -u 1000 executor
 USER executor
 WORKDIR /app
 
-COPY --chown=executor:executor requirements.txt .
+COPY --chown=executor:executor notion/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --user -r requirements.txt
 
-COPY --chown=executor:executor executor.py .
+COPY --chown=executor:executor notion/executor.py ./executor.py
 
 ENTRYPOINT ["python", "executor.py"]

--- a/src/taskrunner/orchestrator.py
+++ b/src/taskrunner/orchestrator.py
@@ -618,13 +618,15 @@ def _ensure_image(image: str) -> None:
         # executor-gmail-modify -> dockerfile src/executors/gmail_modify/Dockerfile
         # with shared context src/executors/ (allows shared modules).
         name = tag.removeprefix("executor-").replace("-", "_")
-        context = Path("src/executors") / name
-        dockerfile = context / "Dockerfile"
+        context = Path("src/executors")
+        dockerfile = context / name / "Dockerfile"
         build_cmd = [
             "docker",
             "build",
             "-t",
             image,
+            "-f",
+            str(dockerfile),
             str(context),
         ]
     elif tag == "llm-runner":


### PR DESCRIPTION
The build context was set to `src/executors/` but Dockerfiles expect their own directory (e.g. `src/executors/notion/`). This caused `COPY executor.py` to fail for the new Notion executor since `executor.py` wasn't in the root of `src/executors/`.

Found during autonomous testing of the Notion tool.