### PR TITLE
fix: skip coherence check for ALLOW-listed tools

### DIFF
--- a/src/taskrunner/container_agent.py
+++ b/src/taskrunner/container_agent.py
@@ -326,8 +326,9 @@ def _handle_tool_request(
                     )
                     return None, pending_result
 
-        # Guardian coherence check
-        if guardian is not None and hasattr(guardian, "check_coherence"):
+        # Guardian coherence check (skip for ALLOW-listed tools — already policy-approved)
+        _policy_verdict = decision.verdict if guardian is not None else None
+        if guardian is not None and hasattr(guardian, "check_coherence") and _policy_verdict != ActionVerdict.ALLOW:
             user_request = ""
             for msg in reversed(messages):
                 if msg.get("role") == "user":

--- a/uv.lock
+++ b/uv.lock
@@ -937,6 +937,7 @@ browser = [
     { name = "playwright" },
 ]
 dev = [
+    { name = "playwright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -980,6 +981,7 @@ requires-dist = [
     { name = "onnxruntime", marker = "extra == 'guardian'", specifier = ">=1.16.0" },
     { name = "optimum", extras = ["onnxruntime"], marker = "extra == 'guardian'", specifier = ">=1.14.0" },
     { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40.0" },
+    { name = "playwright", marker = "extra == 'dev'", specifier = ">=1.40.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pyrage", specifier = ">=1.2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },


### PR DESCRIPTION
Tools in the allow policy list were still getting coherence-checked, causing false positives. For example, list_files was blocked because coherence thought set_workspace should be called first.

Allow-listed tools are already policy-approved — coherence validation is redundant and causes the agent to burn all its turns retrying blocked calls.