### PR TITLE
fix: Telegram channel security hardening

### DIFF
--- a/src/taskrunner/channels/telegram.py
+++ b/src/taskrunner/channels/telegram.py
@@ -49,6 +49,12 @@ class TelegramChannel(WebhookChannelMixin, Channel):
         self._webhook_path = webhook_path
         self._webhook_secret = webhook_secret
         self._send_typing = send_typing
+
+        if mode == "webhook" and not webhook_secret:
+            logger.warning(
+                "Telegram webhook mode with no secret — "
+                "any sender can push updates to the webhook endpoint"
+            )
         self._callback: Callable[[str, str], str] | None = None
         self._bot_username: str = ""
 
@@ -114,7 +120,8 @@ class TelegramChannel(WebhookChannelMixin, Channel):
                     if text is None:
                         continue
 
-                    logger.info("Telegram from %s (@%s): %s", msg.sender_id, msg.sender_username, text[:80])
+                    logger.info("Telegram from %s (@%s)", msg.sender_id, msg.sender_username)
+                    logger.debug("Telegram message text: %s", text[:80])
 
                     if self._send_typing:
                         self._bridge.send_typing(msg.chat_id)

--- a/src/taskrunner/channels/telegram_bridge.py
+++ b/src/taskrunner/channels/telegram_bridge.py
@@ -64,8 +64,13 @@ class TelegramBridge(ABC):
         """Remove the current webhook."""
 
     @abstractmethod
-    def get_file_url(self, file_id: str) -> str:
-        """Return a download URL for a file by file_id."""
+    def download_file(self, file_id: str) -> bytes:
+        """Download a file by file_id and return its contents.
+
+        The download URL contains the bot token, so this method fetches the
+        file server-side and returns raw bytes — the URL is never exposed to
+        callers (and must never be passed to the LLM).
+        """
 
     def health(self) -> dict:
         """Return bridge health status."""
@@ -131,10 +136,15 @@ class HttpTelegramBridge(TelegramBridge):
         self._call("deleteWebhook")
         logger.info("Telegram webhook deleted")
 
-    def get_file_url(self, file_id: str) -> str:
+    def download_file(self, file_id: str) -> bytes:
+        import httpx
+
         result = self._call("getFile", file_id=file_id)
         file_path = result.get("file_path", "")
-        return f"https://api.telegram.org/file/bot{self._token}/{file_path}"
+        url = f"https://api.telegram.org/file/bot{self._token}/{file_path}"
+        resp = httpx.get(url, timeout=30)
+        resp.raise_for_status()
+        return resp.content
 
     def health(self) -> dict:
         try:

--- a/tests/test_telegram_channel.py
+++ b/tests/test_telegram_channel.py
@@ -50,8 +50,8 @@ class MockBridge(TelegramBridge):
     def delete_webhook(self):
         self._webhook_deleted = True
 
-    def get_file_url(self, file_id):
-        return f"https://example.com/{file_id}"
+    def download_file(self, file_id):
+        return b"fake-file-content"
 
     def health(self):
         return {"healthy": True}


### PR DESCRIPTION
## Summary
- Replace `get_file_url()` with `download_file()` on `TelegramBridge` — the download URL contains the bot token, so it's now fetched server-side and only raw bytes are returned. Prevents credential leakage to callers/LLM.
- Add `logger.warning` in `TelegramChannel.__init__` when webhook mode is used without a `webhook_secret`, as defense-in-depth beyond the Pydantic validator.
- Move message content from `logger.info` to `logger.debug` — only sender ID/username logged at info level now.

## Test plan
- [x] All 41 Telegram tests pass
- [x] `MockBridge` updated to implement `download_file()` instead of `get_file_url()`