### PR TITLE
feat: add common dev tools to coding executor image

### DIFF
--- a/src/executors/coding/Dockerfile
+++ b/src/executors/coding/Dockerfile
@@ -9,6 +9,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         make \
+        cmake \
+        pkg-config \
+        libssl-dev \
+        libffi-dev \
+        openssh-client \
+        sqlite3 \
+        unzip \
+        zip \
+        tree \
+        ripgrep \
         ca-certificates \
         gnupg \
     && mkdir -p /etc/apt/keyrings \


### PR DESCRIPTION
## Summary

- Add native build deps (`cmake`, `pkg-config`, `libssl-dev`, `libffi-dev`) that cover the most common `pip install` failures for packages with C extensions (cryptography, etc.)
- Add `openssh-client` so `git clone` works with SSH URLs
- Add `sqlite3`, `unzip`/`zip`, `tree`, and `ripgrep` for general dev utility

## Test plan

- [ ] Build the image: `docker build -f src/executors/coding/Dockerfile src/executors/`
- [ ] Verify new binaries are available: `cmake --version`, `rg --version`, `sqlite3 --version`, `ssh -V`, `tree --version`, `zip --version`, `unzip -v`
- [ ] Run `pip install cryptography` inside the container to confirm native build deps work