### PR TITLE
fix: /allow overrides skip coherence check (#288)

### DIFF
--- a/src/creel/agent.py
+++ b/src/creel/agent.py
@@ -195,9 +195,17 @@ def _check_guardian_pre_execution(
                 error_message=decision.reason,
             )
 
-    # Stage 2: Coherence check
+    # Stage 2: Coherence check — skip if tool has an active /allow override
+    _has_allow_override = False
+    if hasattr(guardian, "override_manager"):
+        from guardian.types import ActionVerdict
+
+        override_result = guardian.override_manager.check(tool_name, tool_input)
+        if override_result and override_result.verdict == ActionVerdict.ALLOW:
+            _has_allow_override = True
+
     user_request = _extract_last_user_text(messages)
-    if user_request:
+    if user_request and not _has_allow_override:
         prior_tools = _extract_prior_tools(messages)
         available_tool_names = registry.all_tool_names() if registry is not None else None
         coherence = guardian.check_coherence(

--- a/src/creel/container_agent.py
+++ b/src/creel/container_agent.py
@@ -678,8 +678,18 @@ def _handle_tool_request(
                     )
                     return None, pending_result
 
-        # Guardian coherence check
-        if guardian is not None and hasattr(guardian, "check_coherence"):
+        # Guardian coherence check — skip if tool has an active /allow override
+        _has_allow_override = False
+        if guardian is not None and hasattr(guardian, "override_manager"):
+            override_result = guardian.override_manager.check(tool_name, tool_input)
+            if override_result and override_result.verdict == ActionVerdict.ALLOW:
+                _has_allow_override = True
+
+        if (
+            guardian is not None
+            and hasattr(guardian, "check_coherence")
+            and not _has_allow_override
+        ):
             user_request = _extract_user_request_for_coherence(messages)
 
             if user_request:


### PR DESCRIPTION
When the user grants `/allow` for a tool, the coherence checker now skips that tool. Prevents multi-step workflows from being blocked after explicit user approval.

Applied to both container and non-container agent paths.

Closes #288