### PR TITLE
fix: Sanitize empty text content blocks before API calls (#290)

### DIFF
--- a/src/creel/agent.py
+++ b/src/creel/agent.py
@@ -563,6 +563,11 @@ def _execute_single_tool(
                 )
             result = redacted_result
 
+    # Ensure content is never empty — the Anthropic API rejects
+    # text content blocks with empty strings.
+    if not result or (isinstance(result, str) and not result.strip()):
+        result = "Tool execution failed (no details available)" if is_error else "(no output)"
+
     tool_history.append(
         {
             "tool": tool_name,

--- a/src/creel/container_agent.py
+++ b/src/creel/container_agent.py
@@ -816,6 +816,11 @@ def _handle_tool_request(
                 )
                 is_error = True
 
+        # Ensure content is never empty — the Anthropic API rejects
+        # text content blocks with empty strings.
+        if not result or (isinstance(result, str) and not result.strip()):
+            result = "Tool execution failed (no details available)" if is_error else "(no output)"
+
         results.append(
             {
                 "tool_use_id": tool_id,

--- a/src/creel/providers/anthropic.py
+++ b/src/creel/providers/anthropic.py
@@ -113,6 +113,38 @@ class AnthropicProvider(LLMProvider):
             self._client = _get_client()
         return self._client
 
+    @staticmethod
+    def _sanitize_messages(messages: list[dict]) -> list[dict]:
+        """Remove empty text content blocks that would cause API 400 errors.
+
+        The Anthropic API rejects messages containing text blocks with empty
+        or whitespace-only text.  This can happen when Guardian blocks a tool
+        call and synthetic error results are stored in conversation history.
+        """
+        sanitized: list[dict] = []
+        for msg in messages:
+            content = msg.get("content")
+            if isinstance(content, list):
+                cleaned = [
+                    block
+                    for block in content
+                    if not (
+                        isinstance(block, dict)
+                        and block.get("type") == "text"
+                        and not (block.get("text") or "").strip()
+                    )
+                ]
+                if not cleaned:
+                    # All blocks were empty — replace with a placeholder so
+                    # the message isn't dropped (preserves conversation flow).
+                    cleaned = [{"type": "text", "text": "(empty)"}]
+                sanitized.append({**msg, "content": cleaned})
+            elif isinstance(content, str) and not content.strip():
+                sanitized.append({**msg, "content": "(empty)"})
+            else:
+                sanitized.append(msg)
+        return sanitized
+
     def create(
         self,
         *,
@@ -126,6 +158,7 @@ class AnthropicProvider(LLMProvider):
         client = self._get_client()
 
         resolved_system, resolved_messages = self._resolve_for_oauth(system, messages)
+        resolved_messages = self._sanitize_messages(resolved_messages)
 
         create_kwargs: dict = {
             "model": model,
@@ -160,6 +193,7 @@ class AnthropicProvider(LLMProvider):
         client = self._get_client()
 
         resolved_system, resolved_messages = self._resolve_for_oauth(system, messages)
+        resolved_messages = self._sanitize_messages(resolved_messages)
 
         create_kwargs: dict = {
             "model": model,

--- a/src/llm/_provider.py
+++ b/src/llm/_provider.py
@@ -44,6 +44,31 @@ class ContainerLLMResponse:
 class ContainerProvider:
     """Base interface for container LLM providers."""
 
+    @staticmethod
+    def _sanitize_messages(messages: list[dict]) -> list[dict]:
+        """Remove empty text content blocks that would cause API 400 errors."""
+        sanitized: list[dict] = []
+        for msg in messages:
+            content = msg.get("content")
+            if isinstance(content, list):
+                cleaned = [
+                    block
+                    for block in content
+                    if not (
+                        isinstance(block, dict)
+                        and block.get("type") == "text"
+                        and not (block.get("text") or "").strip()
+                    )
+                ]
+                if not cleaned:
+                    cleaned = [{"type": "text", "text": "(empty)"}]
+                sanitized.append({**msg, "content": cleaned})
+            elif isinstance(content, str) and not content.strip():
+                sanitized.append({**msg, "content": "(empty)"})
+            else:
+                sanitized.append(msg)
+        return sanitized
+
     def create(
         self,
         *,
@@ -84,6 +109,7 @@ class AnthropicContainerProvider(ContainerProvider):
         tools: list[dict] | None = None,
     ) -> ContainerLLMResponse:
         resolved_system, resolved_messages = self._resolve_for_oauth(system, messages)
+        resolved_messages = self._sanitize_messages(resolved_messages)
         kwargs: dict[str, Any] = {
             "model": model,
             "max_tokens": max_tokens,
@@ -212,10 +238,11 @@ class BedrockContainerProvider(ContainerProvider):
         system: str | None = None,
         tools: list[dict] | None = None,
     ) -> ContainerLLMResponse:
+        sanitized_messages = self._sanitize_messages(messages)
         body: dict[str, Any] = {
             "anthropic_version": "bedrock-2023-05-31",
             "max_tokens": max_tokens,
-            "messages": messages,
+            "messages": sanitized_messages,
         }
         if system:
             body["system"] = system


### PR DESCRIPTION
Prevents sessions from becoming permanently broken after Guardian blocks.

- Added `_sanitize_messages()` in both provider paths (anthropic.py + _provider.py) that strips empty text blocks before API calls
- Audited all synthetic tool results in container_agent.py and agent.py — safeguard replaces empty content with placeholder text
- 26 tests passing

Closes #290