### PR TITLE
fix: Container build pipeline — base image tag + npm visibility

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -1,0 +1,1 @@
+print("Hello from Claude Code!")

--- a/src/creel/containers.py
+++ b/src/creel/containers.py
@@ -181,6 +181,13 @@ def _ensure_base_image() -> str:
         capture_output=True,
     )
     if inspect.returncode == 0:
+        # Ensure :latest alias points to this image so child Dockerfiles
+        # using FROM creel-executor-base:latest resolve correctly.
+        latest = f"{_BASE_IMAGE_NAME}:latest"
+        subprocess.run(
+            ["docker", "tag", tagged, latest],
+            capture_output=True,
+        )
         return tagged
 
     if not _BASE_DOCKERFILE.exists():
@@ -388,8 +395,16 @@ def _build_image(
     )
     if build_result.returncode != 0:
         build_err = build_result.stderr.strip() if build_result.stderr else "unknown error"
+        build_out = build_result.stdout.strip() if build_result.stdout else ""
         logger.error("Docker build failed for %s:\n%s", tags[0], build_err)
+        if build_out:
+            logger.error("Docker build stdout for %s:\n%s", tags[0], build_out)
         raise RuntimeError(f"Docker build failed for {tags[0]}: {build_err[:500]}")
+
+    # Log build output for debugging (npm install failures, warnings, etc.)
+    build_out = build_result.stdout.strip() if build_result.stdout else ""
+    if build_out:
+        logger.debug("Docker build output for %s:\n%s", tags[0], build_out)
 
 
 def collect_required_images(agent_def: AgentDefinition) -> list[str]:

--- a/src/executors/coding/Dockerfile
+++ b/src/executors/coding/Dockerfile
@@ -32,9 +32,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install coding agents globally (|| true: optional, build succeeds without them)
+# Install coding agents globally
 # --ignore-scripts: prevent postinstall execution from untrusted packages
-RUN npm install -g --ignore-scripts @anthropic-ai/claude-code @openai/codex || true
+RUN npm install -g --ignore-scripts @anthropic-ai/claude-code @openai/codex
 
 # Default workspace directory
 RUN mkdir -p /workspace && chown executor:executor /workspace
@@ -45,5 +45,8 @@ WORKDIR /workspace
 # Copy executor scripts
 COPY --chown=executor:executor coding/executor.py /app/executor.py
 COPY --chown=executor:executor coding/dev_runner.py /app/dev_runner.py
+
+# Ensure python symlink exists (some base image variants only have python3)
+RUN ln -sf $(which python3) /usr/local/bin/python 2>/dev/null || true
 
 ENTRYPOINT ["python", "/app/executor.py"]

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -52,9 +52,10 @@ class TestEnsureBaseImage:
         mock_run.return_value = MagicMock(returncode=0)  # docker inspect succeeds
         result = _ensure_base_image()
         assert result.startswith("creel-executor-base:")
-        # Only docker inspect was called, not docker build
-        assert mock_run.call_count == 1
-        assert "inspect" in mock_run.call_args[0][0][2]
+        # docker inspect + docker tag (to ensure :latest alias)
+        assert mock_run.call_count == 2
+        assert "inspect" in mock_run.call_args_list[0][0][0][2]
+        assert "tag" in mock_run.call_args_list[1][0][0][1]
 
     @patch("creel.containers._build_image")
     @patch("subprocess.run")


### PR DESCRIPTION
1. Re-tag :latest on cache hit so child images resolve correctly
2. Remove || true from npm install — failures now visible  
3. Build log capture for debugging