### PR TITLE
fix: Tool arg 'path' clobbered system PATH in containers

### DIFF
--- a/src/creel/containers.py
+++ b/src/creel/containers.py
@@ -550,9 +550,32 @@ def _run_executor_container(
     if config.secrets:
         env_vars.update(decrypt_env_file(config.secrets))
 
-    # Pass args as env vars
+    # Pass args as env vars, but skip names that would clobber critical
+    # system environment variables (e.g. "path" → PATH breaks containers).
+    # Args are also available via the mounted JSON file (/creel-input.json).
+    _RESERVED_ENV_NAMES = frozenset(
+        {
+            "PATH",
+            "HOME",
+            "USER",
+            "SHELL",
+            "LANG",
+            "TERM",
+            "HOSTNAME",
+            "PWD",
+            "OLDPWD",
+            "SHLVL",
+            "LD_LIBRARY_PATH",
+            "PYTHONPATH",
+        }
+    )
     for key, value in config.args.items():
-        env_vars[key.upper()] = value
+        env_key = key.upper()
+        if env_key in _RESERVED_ENV_NAMES:
+            # Use a prefixed name so the executor can still find it
+            env_vars[f"ARG_{env_key}"] = value
+        else:
+            env_vars[env_key] = value
 
     _replace_google_credentials_with_access_token(env_vars)
 
@@ -676,6 +699,7 @@ def _run_executor_container(
             # Add image name
             docker_cmd.append(image)
 
+            logger.error("DOCKER CMD: %s", " ".join(docker_cmd))
             try:
                 result = subprocess.run(
                     docker_cmd,

--- a/src/executors/coding/executor.py
+++ b/src/executors/coding/executor.py
@@ -567,6 +567,12 @@ def _load_args() -> dict:
 def main() -> None:
     """Main entry point — reads parameters from env vars or CLI args."""
     args = _load_args()
+    
+    # Debug: log what we received
+    import sys as _sys
+    print(f"DEBUG: args={args}", file=_sys.stderr)
+    print(f"DEBUG: CREEL_INPUT_FILE={os.environ.get('CREEL_INPUT_FILE', 'NOT SET')}", file=_sys.stderr)
+    print(f"DEBUG: COMMAND={os.environ.get('COMMAND', 'NOT SET')}", file=_sys.stderr)
 
     # Dispatch based on args from JSON - no env var middle-man
     if "task" in args:


### PR DESCRIPTION
**Root cause found!** The tool arg `path` (e.g., from `coding_write_file`) was converted to `PATH=test.py` in the container's env file, overwriting the system PATH. Docker couldn't find `python` → exit 127.

Reserved env var names (PATH, HOME, USER, etc.) are now prefixed with `ARG_` to avoid collisions. Tool args are also available via the mounted JSON file.