### PR TITLE
fix: coding_agent auth — map ANTHROPIC_AUTH_TOKEN to CLAUDE_CODE_OAUTH_TOKEN

### DIFF
--- a/src/creel/containers.py
+++ b/src/creel/containers.py
@@ -550,6 +550,14 @@ def _run_executor_container(
     if config.secrets:
         env_vars.update(decrypt_env_file(config.secrets))
 
+    # Claude Code CLI uses CLAUDE_CODE_OAUTH_TOKEN, not ANTHROPIC_AUTH_TOKEN.
+    # When both are present, Claude Code prefers ANTHROPIC_AUTH_TOKEN and fails
+    # with "OAuth authentication is currently not supported". Remove the old
+    # var and set the correct one so coding_agent can authenticate.
+    if config.name == "coding" and "ANTHROPIC_AUTH_TOKEN" in env_vars:
+        token = env_vars.pop("ANTHROPIC_AUTH_TOKEN")
+        env_vars.setdefault("CLAUDE_CODE_OAUTH_TOKEN", token)
+
     # Pass args as env vars, but skip names that would clobber critical
     # system environment variables (e.g. "path" → PATH breaks containers).
     # Args are also available via the mounted JSON file (/creel-input.json).

--- a/src/executors/coding/executor.py
+++ b/src/executors/coding/executor.py
@@ -511,7 +511,7 @@ def run_agent(
 
     try:
         result = subprocess.run(
-            ["claude", "--print", "--permission-mode", "plan", "--", task],
+            ["claude", "--print", "--permission-mode", "bypassPermissions", "--", task],
             cwd=effective_workdir,
             capture_output=True,
             text=True,
@@ -567,12 +567,6 @@ def _load_args() -> dict:
 def main() -> None:
     """Main entry point — reads parameters from env vars or CLI args."""
     args = _load_args()
-    
-    # Debug: log what we received
-    import sys as _sys
-    print(f"DEBUG: args={args}", file=_sys.stderr)
-    print(f"DEBUG: CREEL_INPUT_FILE={os.environ.get('CREEL_INPUT_FILE', 'NOT SET')}", file=_sys.stderr)
-    print(f"DEBUG: COMMAND={os.environ.get('COMMAND', 'NOT SET')}", file=_sys.stderr)
 
     # Dispatch based on args from JSON - no env var middle-man
     if "task" in args:


### PR DESCRIPTION
## Problem
Claude Code CLI in containers failed with:
```
401 OAuth authentication is currently not supported
```

**Root cause:** The coding container received `ANTHROPIC_AUTH_TOKEN` from decrypted secrets, but Claude Code CLI requires `CLAUDE_CODE_OAUTH_TOKEN` for OAuth auth. When `ANTHROPIC_AUTH_TOKEN` is present, Claude Code picks it up first and attempts API-style auth which fails.

## Fix
- **containers.py:** For the coding executor, pop `ANTHROPIC_AUTH_TOKEN` from env vars and set `CLAUDE_CODE_OAUTH_TOKEN` instead
- **executor.py:** Switch from `--permission-mode plan` to `--permission-mode bypassPermissions` (plan mode was blocking file writes, defeating the purpose)
- **executor.py:** Remove debug logging from PATH investigation

## Testing
- Verified Claude Code authenticates and completes tasks in container
- 43 container tests pass
- Rebuilt executor-coding Docker image