### PR TITLE
docs: update website and add missing executor docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,4 @@ workspace/memory/
 # Coverage
 .coverage
 
-# MkDocs build output (except site project Vercel config)
-site/*
-!site/vercel.json
+

--- a/docs/architecture/channels.md
+++ b/docs/architecture/channels.md
@@ -11,11 +11,8 @@ The registry uses a two-phase discovery strategy: packaging-based entry points f
 ```mermaid
 flowchart TD
     R["ChannelRegistry.discover()"] --> EP["Scan entry points\ngroup: creel.channels"]
-    EP --> found{"Any plugins\nfound?"}
-    found -- yes --> REG["Register all discovered plugins"]
-    found -- no --> BI["Fallback: import built-in\nchannel modules directly"]
-    BI --> REG
-    REG --> AVAIL["registry.available()\nfiltered by platform"]
+    EP --> BI["Import built-in channel modules\nfor any not yet registered"]
+    BI --> AVAIL["registry.available()\nfiltered by platform"]
 ```
 
 **Entry points** are declared in `pyproject.toml`:
@@ -28,7 +25,7 @@ whatsapp = "creel.channels.whatsapp:register_plugin"
 telegram = "creel.channels.telegram:register_plugin"
 ```
 
-When entry points aren't available (e.g. running from source with `PYTHONPATH`), the registry falls back to directly importing the modules listed in `ChannelRegistry._BUILTIN_CHANNELS`.
+After scanning entry points, the registry always attempts to import built-in channel modules for any channels not yet registered. This covers development setups (e.g. running from source with `PYTHONPATH`) and partial entry-point discovery.
 
 ## Plugin Anatomy
 
@@ -127,13 +124,13 @@ Messages are dropped unless the sender matches `allowed_senders`. For group-capa
 ```yaml
 channels:
   telegram:
-    bot_token: ${TELEGRAM_BOT_TOKEN}
+    secrets: secrets/telegram.env.enc
     allowed_senders: ["12345678", "@myusername"]
     allowed_chats: ["-100987654"]
 ```
 
-!!! warning "Mandatory allow-list"
-    If `allowed_senders` is empty or omitted, **all inbound messages are rejected**. There is no open-to-all mode — this is a deliberate security default.
+!!! warning "Default: closed access"
+    With the default `sender_policy: closed`, if `allowed_senders` is empty or omitted, **all inbound messages are rejected**. Set `sender_policy: allowlist` or `sender_policy: open` for more permissive modes (see [Telegram setup](../getting-started/telegram.md#sender-policy)).
 
 ### Outbound filtering
 

--- a/docs/architecture/guardian.md
+++ b/docs/architecture/guardian.md
@@ -8,7 +8,7 @@ The Guardian layer screens inputs and validates tool calls before they execute. 
 flowchart TD
     A["Incoming message"] --> B["screen_input(text)\n← before session history"]
     B --> FC["FastClassifier\nDeBERTa/ONNX, ~10ms"]
-    B --> LJ["LLMJudge\nHaiku, ~300ms, off by default"]
+    B --> LJ["LLMJudge\nHaiku, ~300ms, uncertain only"]
     FC --> blocked{"blocked?"}
     LJ --> blocked
     blocked -- yes --> reject["Return rejection,\nskip agent loop"]
@@ -30,25 +30,83 @@ flowchart TD
 | Stage | Component | What it does |
 |-------|-----------|--------------|
 | 1 | Fast classifier | Local DeBERTa model scores prompt-injection likelihood against a confidence threshold |
-| 2 | LLM judge | Secondary Haiku-based check (disabled by default) |
+| 2 | LLM judge | Secondary Haiku-based check (enabled by default, fires only when classifier is uncertain) |
 | 3a | Temporary overrides | Time-limited allow/deny rules checked before static policy (`/allow`, `/deny` commands) |
 | 3b | Policy engine | `fnmatch` rules in `policies/default.yaml` map tool names to allow/review/deny |
-| 4 | Coherence check | LLM-based check that tool calls match the user's original intent (catches prompt injection causing unrelated actions) |
-| 5 | Network policy | Domain allowlist/blocklist, request/response size limits, and per-executor rate limiting for outbound HTTP requests |
+| 4 | Coherence check | LLM-based check that tool calls match the user's original intent (disabled by default, opt-in) |
+| 5 | Credential scanner | Scans tool output for leaked credentials before returning results to the LLM |
+| 6 | Drift detection | Detects when agent behavior drifts from the user's original intent over multi-turn conversations |
+| 7 | Network policy | Domain allowlist/blocklist, request/response size limits, and per-executor rate limiting for outbound HTTP requests |
 
 ## Policy Rules
 
 Policy rules are defined in `policies/default.yaml`:
 
 ```yaml
-allow:  [check_weather, check_calendar, check_email, read_email, check_drive, check_messages, get_chats, react_imessage]
-review: [send_*, upload_*, create_*, mark_*, trash_*]
+allow:
+  - check_weather
+  - check_calendar
+  - check_email
+  - read_email
+  - check_drive
+  - read_doc
+  - read_sheet
+  - notion_api
+  - check_messages
+  - get_chats
+  - react_imessage
+  - list_notes
+  - search_notes
+  - read_clipboard
+  - github
+  - web_search
+  - fetch_url
+  - synthesize_speech
+  - remember
+  - search_memory
+  # ... 40+ read-only tools total
+
+review:
+  - send_*
+  - upload_*
+  - create_*
+  - mark_*
+  - trash_*
+  - write_clipboard
+  - host_exec
+  - host_process
+  - dev_exec
+  - dev_process
+  - coding
+  - exec_interactive
+  - git_commit
+  - git_push
+  - notion_write
+  # ... plus browser, file ops, etc.
+
 deny:   [delete_*]
 
-# Tools that match 'review' rules but can skip human approval
+# Conditional deny rules block dangerous shell patterns
+# (rm -rf, reverse shells, fork bombs, pipe injection, etc.)
+# Applied to exec, host_exec, dev_exec, coding, exec_interactive
+deny_when:
+  - tool: exec
+    arg: command
+    pattern: "*rm -rf*"
+  # ... 100+ patterns across all exec-like tools
+
 auto_approve:
   - mark_read
   - react_imessage
+  - remember
+  - write_clipboard
+  - create_note
+  - create_reminder
+  - browser_open
+  - browser_navigate
+  - write_file
+  - edit_file
+  # ... 20+ tools that skip human confirmation
 ```
 
 Deny wins over review, review wins over allow. Unknown tools default to review. Tools listed in `auto_approve` skip the human confirmation prompt even when matched by a review rule.
@@ -189,13 +247,14 @@ guardian:
     default_on_timeout: deny
   fast_classifier:
     enabled: true
-    threshold: 0.95
+    threshold: 0.85
     model_name: protectai/deberta-v3-base-prompt-injection-v2
   llm_judge:
-    enabled: false
-  coherence:
     enabled: true
-    model: claude-haiku-4-5-20251001
+    uncertain_only: true
+  coherence:
+    enabled: false
+    model: claude-haiku-4-5
     max_tokens: 256
   policy:
     enabled: true

--- a/docs/configuration/agent-config.md
+++ b/docs/configuration/agent-config.md
@@ -9,31 +9,26 @@ system_prompt: |
   You are a personal assistant. Be concise and helpful.
   Today is {date}.
 
-tools:
-  check_weather:
-    executor: weather
-    description: "Get current weather and forecast"
-    parameters:
-      location:
-        type: string
-        description: "City name or coordinates"
-        required: true
+skills:
+  weather:
+    # Executor auto-detected from skill ID
+    tools:
+      check_weather:
+        description: "Get current weather and forecast"
 
-  check_email:
-    executor: gmail_readonly
+  gmail_readonly:
     secrets: secrets/gmail.env.enc
-    description: "Search Gmail for emails"
-    parameters:
-      query:
-        type: string
-        description: "Gmail search query"
-        required: true
+    tools:
+      check_email:
+        description: "Search Gmail for emails"
+      read_email:
+        description: "Read a specific email by ID"
 
-  # ... see agent.yaml for all tools (calendar, drive, iMessage, etc.)
+  # ... see agent.yaml for all skills (calendar, drive, iMessage, etc.)
 
 llm:
   model: claude-sonnet-4-20250514
-  max_tokens: 1024
+  max_tokens: 4096
   secrets: secrets/anthropic.env.enc
 
 agent:
@@ -41,7 +36,6 @@ agent:
 
 session:
   sessions_dir: sessions
-  max_history: 50
   summarize_on_trim: true
   context_pruning:
     enabled: true
@@ -57,7 +51,7 @@ workspace:
   path: workspace
   timezone: "America/Denver"
   memory_days: 2
-  memory_max_chars: 5000
+  memory_max_chars: 20000
   max_chars_per_file: 20000
 
 channels:
@@ -86,7 +80,6 @@ Sessions are stored as JSON files in `sessions/` (gitignored) and persist conver
 | Field | Description |
 |-------|-------------|
 | `sessions_dir` | Directory to store session JSON files |
-| `max_history` | Maximum number of messages to keep in history |
 | `summarize_on_trim` | Build a summarize callback for use by `/compact` and context pruning |
 
 ### Context Pruning
@@ -95,7 +88,7 @@ Context pruning automatically manages the token window during long conversations
 
 | Field | Description |
 |-------|-------------|
-| `context_pruning.enabled` | Enable automatic context pruning (default: `false`) |
+| `context_pruning.enabled` | Enable automatic context pruning (default: `true`) |
 | `context_pruning.threshold` | Fraction of `max_context_tokens` at which pruning triggers (default: `0.80`) |
 | `context_pruning.min_recent_messages` | Number of recent messages to always keep (default: `4`) |
 

--- a/docs/configuration/monitors.md
+++ b/docs/configuration/monitors.md
@@ -72,8 +72,8 @@ monitors:
 | `executor` | yes | — | Executor to fetch data (`gmail_readonly`, `gcal`, `exec`, etc.) |
 | `prompt` | yes | — | What to check for — the LLM evaluates this against executor output |
 | `schedule` | yes | — | 5-part cron expression |
-| `delivery` | no | `announce` | Channel name for alert delivery |
-| `delivery_mode` | no | `announce` | `announce`, `webhook`, or `none` |
+| `delivery` | no | `none` | Channel name for alert delivery |
+| `delivery_mode` | no | `none` | `announce`, `webhook`, or `none` |
 | `delivery_url` | no | — | Webhook URL (required when `delivery_mode: webhook`) |
 | `alert_level` | no | `notice` | `info`, `notice`, or `urgent` |
 | `quiet_hours` | no | — | `HH:MM-HH:MM` range to suppress non-urgent alerts |

--- a/docs/configuration/secrets.md
+++ b/docs/configuration/secrets.md
@@ -40,10 +40,10 @@ This produces `secrets/anthropic.env.enc` and deletes the plaintext file.
 
 ## Key Location
 
-The decryption key path defaults to `~/.age/key.txt`. Override with the `AGE_IDENTITY` environment variable:
+The decryption key path defaults to `~/.age/key.txt`. Override with the `AGE_IDENTITY_FILE` environment variable:
 
 ```bash
-export AGE_IDENTITY=/path/to/key.txt
+export AGE_IDENTITY_FILE=/path/to/key.txt
 ```
 
 ## `.env` File Format

--- a/docs/configuration/tasks.md
+++ b/docs/configuration/tasks.md
@@ -9,15 +9,15 @@ Tasks are YAML files in `tasks/`. Each defines what data to fetch, how to prompt
 name: morning_briefing
 schedule: "0 7 * * *"  # 7am daily
 
-fetch:
+executors:
   calendar:
-    image: executor-gcal:latest
+    executor: gcal
     secrets: secrets/gcal.env.enc
     args:
       range: today
 
   weather:
-    image: executor-weather:latest
+    executor: weather
     args:
       location: denver
 
@@ -35,7 +35,7 @@ output:
   to: "$PHONE"
 
 llm:
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
   max_tokens: 300
   secrets: secrets/anthropic.env.enc
 ```
@@ -46,14 +46,14 @@ llm:
 |-------|----------|-------------|
 | `name` | yes | Unique task identifier |
 | `schedule` | yes | 5-part cron expression |
-| `fetch` | yes | Map of executor name to config |
-| `fetch.<name>.image` | yes | Docker image for containerized mode |
-| `fetch.<name>.secrets` | no | Path to age-encrypted .env file |
-| `fetch.<name>.args` | no | Key-value args passed to the executor |
+| `executors` | no | Map of executor name to config |
+| `executors.<name>.executor` | yes | Executor module name (e.g., `gcal`, `weather`) |
+| `executors.<name>.secrets` | no | Path to age-encrypted .env file |
+| `executors.<name>.args` | no | Key-value args passed to the executor |
 | `prompt` | yes | Prompt template with `{name}` placeholders |
 | `output.type` | yes | `imessage`, `stdout`, or `file` |
 | `output.to` | yes | Phone number, empty string, or file path |
-| `llm.model` | no | Anthropic model ID (default: `claude-sonnet-4-20250514`) |
+| `llm.model` | no | Anthropic model ID (default: `claude-sonnet-4-6`) |
 | `llm.max_tokens` | no | Max response tokens (default: 300) |
 | `llm.secrets` | no | Path to age-encrypted .env with `ANTHROPIC_AUTH_TOKEN` or `ANTHROPIC_API_KEY` |
 
@@ -69,9 +69,9 @@ name: email_triage
 schedule: "0 8 * * *"
 mode: agent
 
-fetch:
+executors:
   gmail:
-    image: executor-gmail:latest
+    executor: gmail_readonly
     secrets: secrets/gmail.env.enc
     args:
       query: "is:unread newer_than:1d"
@@ -101,7 +101,7 @@ output:
   to: "$PHONE"
 
 llm:
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
   max_tokens: 1024
   secrets: secrets/anthropic.env.enc
 ```

--- a/docs/deployment/containers.md
+++ b/docs/deployment/containers.md
@@ -5,21 +5,40 @@ For production use, executors and the LLM runner execute in isolated Docker cont
 ## Building Container Images
 
 ```bash
-# Build container images
-docker build -t executor-weather:latest executors/weather/
-docker build -t executor-gcal:latest executors/gcal/
-docker build -t executor-gcal-write:latest executors/gcal_write/
-docker build -t executor-gmail-readonly:latest executors/gmail_readonly/
-docker build -t executor-gmail-send:latest executors/gmail_send/
-docker build -t executor-gmail-modify:latest executors/gmail_modify/
-docker build -t executor-drive:latest executors/drive/
-docker build -t executor-drive-write:latest executors/drive_write/
-docker build -t executor-bluebubbles:latest executors/bluebubbles/
-docker build -t executor-brave-search:latest executors/brave_search/
-docker build -t executor-fetch-url:latest executors/fetch_url/
-docker build -t executor-exec-interactive:latest -f executors/exec_interactive/Dockerfile executors/
-docker build -t llm-runner:latest llm/
+# Build the shared base image first
+docker build -t creel-executor-base:latest src/executors/base/
+
+# Build executor images (context is src/executors/, -f points to each Dockerfile)
+docker build -t executor-weather:latest -f src/executors/weather/Dockerfile src/executors/
+docker build -t executor-gcal:latest -f src/executors/gcal/Dockerfile src/executors/
+docker build -t executor-gcal-write:latest -f src/executors/gcal_write/Dockerfile src/executors/
+docker build -t executor-gmail-readonly:latest -f src/executors/gmail_readonly/Dockerfile src/executors/
+docker build -t executor-gmail-send:latest -f src/executors/gmail_send/Dockerfile src/executors/
+docker build -t executor-gmail-modify:latest -f src/executors/gmail_modify/Dockerfile src/executors/
+docker build -t executor-drive:latest -f src/executors/drive/Dockerfile src/executors/
+docker build -t executor-drive-write:latest -f src/executors/drive_write/Dockerfile src/executors/
+docker build -t executor-google-docs:latest -f src/executors/google_docs/Dockerfile src/executors/
+docker build -t executor-google-sheets:latest -f src/executors/google_sheets/Dockerfile src/executors/
+docker build -t executor-google-slides:latest -f src/executors/google_slides/Dockerfile src/executors/
+docker build -t executor-brave-search:latest -f src/executors/brave_search/Dockerfile src/executors/
+docker build -t executor-fetch-url:latest -f src/executors/fetch_url/Dockerfile src/executors/
+docker build -t executor-notion:latest -f src/executors/notion/Dockerfile src/executors/
+docker build -t executor-notion-write:latest -f src/executors/notion_write/Dockerfile src/executors/
+docker build -t executor-github:latest -f src/executors/github/Dockerfile src/executors/
+docker build -t executor-tts:latest -f src/executors/tts/Dockerfile src/executors/
+docker build -t executor-exec:latest -f src/executors/exec/Dockerfile src/executors/
+docker build -t executor-exec-interactive:latest -f src/executors/exec_interactive/Dockerfile src/executors/
+docker build -t executor-coding:latest -f src/executors/coding/Dockerfile src/executors/
+docker build -t executor-dev-session:latest -f src/executors/dev_session/Dockerfile src/executors/
+docker build -t executor-file-ops:latest -f src/executors/file_ops/Dockerfile src/executors/
+# ... plus bridge-based executors (clipboard, host_exec, apple_*, things, imessage)
+
+# Build the LLM runner
+docker build -t llm-runner:latest src/llm/
 ```
+
+!!! note
+    In practice, the container runtime auto-builds images on first use and tags them with a content hash for cache invalidation. Manual builds are only needed for pre-warming or CI.
 
 ## Running with Containers
 

--- a/docs/deployment/host-bridge.md
+++ b/docs/deployment/host-bridge.md
@@ -8,11 +8,27 @@ Docker containers are sandboxed and can't access the macOS scripting bridge or a
 
 ## How
 
-A FastAPI server runs as a host process and exposes REST endpoints at `/notes/*`, `/reminders/*`, `/things/*`, and `/imessage/*`. Containerized executors make HTTP requests to these endpoints with scoped authentication tokens.
+A FastAPI server runs as a host process and exposes REST endpoints for macOS-native tools and host operations. Containerized executors make HTTP requests to these endpoints with scoped authentication tokens.
+
+### Endpoint Groups
+
+| Path | Scope | Purpose |
+|------|-------|---------|
+| `/notes/*` | `NOTES` | Apple Notes (read, search, create) |
+| `/reminders/*` | `REMINDERS` | Apple Reminders (list, create, complete) |
+| `/things/*` | `THINGS` | Things 3 task management |
+| `/imessage/*` | `IMESSAGE` | iMessage send/receive |
+| `/clipboard/*` | `CLIPBOARD` | macOS clipboard read/write |
+| `/browser/*` | `BROWSER` | Playwright browser automation |
+| `/git/*` | `GIT` | Git operations (status, diff, log, commit, push) |
+| `/exec` | `EXEC` | Host command execution |
+| `/process` | `EXEC` | Background process management |
+| `/sessions` | `EXEC` | Session listing |
+| `/health` | — | Health check (no auth required) |
 
 ## Security
 
-Each executor receives a scoped token that only grants access to its specific tool endpoints. For example, the `apple_notes` executor can only call `/notes/*` endpoints, not `/reminders/*` or `/things/*`.
+Each executor receives a scoped token that only grants access to its specific endpoint group. For example, the `apple_notes` executor receives a `NOTES`-scoped token and can only call `/notes/*` endpoints, not `/reminders/*`, `/clipboard/*`, or any other group.
 
 ## CLI Integration
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -141,5 +141,5 @@ Quick one-liner to validate a branch:
 # Run tests + import check + security scan
 python3 -m pytest tests/ -x -q && \
 python3 -c "import ast, pathlib; [ast.parse(p.read_text()) for p in pathlib.Path('.').rglob('*.py')]" && \
-grep -rn "shell=True" executors/ creel/ bridge/ 2>/dev/null && echo "⚠️  shell=True found!" || echo "✅ No shell=True"
+grep -rn "shell=True" src/executors/ src/creel/ src/bridge/ 2>/dev/null && echo "⚠️  shell=True found!" || echo "✅ No shell=True"
 ```

--- a/docs/executors/apple-apps.md
+++ b/docs/executors/apple-apps.md
@@ -6,43 +6,63 @@ These executors integrate with macOS applications via the [Host Bridge](../deplo
 
 Reads and creates notes in Notes.app. Uses the `memo` CLI tool for macOS integration.
 
-### Configuration
+### Tools
 
-```yaml
-apple_notes:
-  args:
-    action: "list_notes"   # list_notes, search_notes, read_note, create_note
-    folder: "Notes"
-    limit: "25"
-```
-
-### Parameters
+**`list_notes`** — List notes, optionally filtered by folder.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `action` | yes | `list_notes`, `search_notes`, `read_note`, or `create_note` |
 | `folder` | no | Notes folder name |
-| `limit` | no | Maximum notes to return (default: 25) |
+
+**`search_notes`** — Search notes by text query.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `query` | yes | Search query |
+
+**`read_note`** — Read a specific note.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `note_id` | yes | Note identifier |
+
+**`create_note`** — Create a new note.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `title` | yes | Note title |
+| `body` | no | Note body text |
+| `folder` | no | Folder to create in |
 
 ## Apple Reminders
 
 Reads and creates reminders in Reminders.app. Uses the `remindctl` CLI tool for macOS integration.
 
-### Configuration
+### Tools
 
-```yaml
-apple_reminders:
-  args:
-    action: "list_reminders"  # list_reminders, create_reminder, complete_reminder, get_lists
-    list_name: "Reminders"
-```
-
-### Parameters
+**`list_reminders`** — List reminders from a list.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `action` | yes | `list_reminders`, `create_reminder`, `complete_reminder`, or `get_lists` |
 | `list_name` | no | Reminders list name |
+| `filter` | no | Filter: `incomplete` (default) or `all` |
+
+**`create_reminder`** — Create a new reminder.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `title` | yes | Reminder title |
+| `due_date` | no | Due date |
+| `notes` | no | Additional notes |
+| `list_name` | no | List to add to |
+
+**`complete_reminder`** — Mark a reminder as complete.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `name` | yes | Name of the reminder to complete |
+
+**`get_reminder_lists`** — List available reminder lists. No parameters.
 
 ## Things 3
 

--- a/docs/executors/apple-apps.md
+++ b/docs/executors/apple-apps.md
@@ -48,20 +48,28 @@ apple_reminders:
 
 Manages tasks in Things 3. Uses the `things` CLI tool for macOS integration.
 
-### Configuration
+### Tools
 
-```yaml
-things:
-  args:
-    action: "list_tasks"     # list_tasks, create_task, complete_task, search_tasks
-    area: "Personal"
-    limit: "25"
-```
-
-### Parameters
+**`list_things`** — List tasks from Things 3.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `action` | yes | `list_tasks`, `create_task`, `complete_task`, or `search_tasks` |
-| `area` | no | Things area to filter by |
-| `limit` | no | Maximum tasks to return (default: 25) |
+| `action` | no | `inbox` (default), `today`, `upcoming`, `projects`, or `search` |
+| `query` | no | Search query (required when action is `search`) |
+
+**`create_things_task`** — Create a new task in Things 3.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `title` | yes | Title of the task |
+| `notes` | no | Notes for the task |
+| `when` | no | When to schedule the task |
+| `deadline` | no | Deadline for the task |
+| `tags` | no | Tags for the task |
+| `list` | no | Project or area to add the task to |
+
+**`complete_things_task`** — Mark a task as complete.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `id` | yes | ID of the task to complete |

--- a/docs/executors/clipboard.md
+++ b/docs/executors/clipboard.md
@@ -1,0 +1,43 @@
+# Clipboard
+
+The clipboard executor provides read/write access to the macOS system clipboard via the host bridge.
+
+## Requirements
+
+- macOS only
+- Bridge service running (`bridge.enabled: true` in `agent.yaml`)
+
+## Tools
+
+### `read_clipboard`
+
+Read the current clipboard contents.
+
+```json
+{"tool": "read_clipboard"}
+```
+
+### `write_clipboard`
+
+Write text to the clipboard.
+
+```json
+{"tool": "write_clipboard", "args": {"text": "Hello, world!"}}
+```
+
+## How It Works
+
+The executor communicates with the bridge server over HTTP rather than calling `pbcopy`/`pbpaste` directly. This keeps clipboard access mediated through the bridge's authentication layer.
+
+- **Bridge endpoints**: `POST /clipboard/read`, `POST /clipboard/write`
+- **Authentication**: Bearer token via `BRIDGE_TOKEN`
+- **Timeout**: 30 seconds
+
+## Security
+
+| Property | Value |
+|----------|-------|
+| Credentials | Bridge HTTP token (scoped) |
+| Platform | macOS only |
+| Network | Bridge server only |
+| Container isolation | Yes (production) |

--- a/docs/executors/dev-session.md
+++ b/docs/executors/dev-session.md
@@ -1,0 +1,66 @@
+# Dev Session
+
+The dev session executor provides a containerized development environment with long-lived process management. Unlike the standard `exec` executor, dev sessions persist across tool calls, allowing background processes and interactive workflows.
+
+!!! note
+    This executor only works in container mode. It is not available in subprocess/development mode.
+
+## Tools
+
+### `dev_exec`
+
+Run a command in the dev container.
+
+```json
+{
+  "tool": "dev_exec",
+  "args": {
+    "command": "python app.py",
+    "background": true,
+    "workdir": "/workspace",
+    "timeout": 300
+  }
+}
+```
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `command` | Yes | — | Command to execute |
+| `background` | No | `false` | Run in background, returns a session ID |
+| `workdir` | No | Container default | Working directory |
+| `timeout` | No | `300` | Timeout in seconds (foreground only) |
+
+### `dev_process`
+
+Manage a running background process.
+
+```json
+{"tool": "dev_process", "args": {"session_id": "abc123", "action": "log"}}
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `session_id` | Yes | Session ID from `dev_exec` |
+| `action` | Yes | `log`, `poll`, `write`, or `kill` |
+| `limit` | No | Max log lines (default 100) |
+| `offset` | No | Line offset (default 0) |
+| `data` | No | Stdin data (for `write` action) |
+
+### `dev_sessions`
+
+List all active sessions. No parameters.
+
+## Configuration
+
+In `agent.yaml`:
+
+```yaml
+tools:
+  dev_session:
+    writable: true
+    memory: 512m
+    cpus: 1.0
+    tmpfs_size: 256M
+    timeout: 300
+    network: true
+```

--- a/docs/executors/github.md
+++ b/docs/executors/github.md
@@ -81,7 +81,7 @@ The executor enforces a built-in allowlist (see `src/executors/github/executor.p
 
 ### Always allowed (read-only)
 
-`issue list`, `issue view`, `pr list`, `pr view`, `pr diff`, `pr checks`, `run list`, `run view`, `run watch`, `search code`, `search issues`, `search prs`
+`issue list`, `issue view`, `pr list`, `pr view`, `pr diff`, `pr checks`, `run list`, `run view`, `run watch`, `search code`, `search issues`, `search prs`, `search repos`, `search commits`, `repo list`, `repo view`, `repo clone`
 
 ### Require review (write operations)
 

--- a/docs/executors/gmail.md
+++ b/docs/executors/gmail.md
@@ -11,25 +11,23 @@ python scripts/setup-google-oauth.py gmail --encrypt
 
 The executor uses a read-only scope (`gmail.readonly`).
 
-### Configuration
+### Tools
 
-```yaml
-gmail_readonly:
-  image: executor-gmail-readonly:latest
-  secrets: secrets/gmail.env.enc
-  args:
-    query: "is:unread newer_than:1d"   # Gmail search syntax
-    max_results: "20"                   # max messages to fetch
-    message_id: ""                      # set to read a specific email by ID
-```
+The executor exposes two tools:
 
-### Parameters
+**`check_email`** — Search for emails matching a query.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `query` | yes | Gmail search query |
 | `max_results` | no | Maximum messages to return (default: 20) |
-| `message_id` | no | Specific message ID to read in full |
+| `full_body` | no | Include full body in search results (default: false) |
+
+**`read_email`** — Read a specific email by ID.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `message_id` | yes | Gmail message ID |
 
 When reading a single message by ID, the full decoded body is returned (prefers `text/plain`, falls back to HTML stripping via BeautifulSoup).
 
@@ -69,24 +67,21 @@ Modifies, trashes, or permanently deletes Gmail messages. Requires a one-time OA
 python scripts/setup-google-oauth.py gmail_modify --encrypt
 ```
 
-### Configuration
+### Tools
 
-```yaml
-gmail_modify:
-  image: executor-gmail-modify:latest
-  secrets: secrets/gmail_modify.env.enc
-  args:
-    action: "modify"              # modify, trash, or delete
-    message_id: "18f1a2b3c4d5e6f" # Gmail message ID
-    add_labels: "STARRED"         # comma-separated label IDs (modify only)
-    remove_labels: "UNREAD,INBOX" # comma-separated label IDs (modify only)
-```
+The executor exposes two tools:
 
-### Parameters
+**`trash_email`** — Move an email to trash.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `action` | yes | `modify`, `trash`, or `delete` |
 | `message_id` | yes | Gmail message ID |
-| `add_labels` | no | Comma-separated label IDs to add (modify only) |
-| `remove_labels` | no | Comma-separated label IDs to remove (modify only) |
+| `subject` | yes | Email subject (for confirmation) |
+
+**`mark_read`** — Mark an email as read.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `message_id` | yes | Gmail message ID |
+
+The underlying executor also supports `modify` (add/remove labels), `delete` (permanent), and batch operations via direct invocation.

--- a/docs/executors/host-exec.md
+++ b/docs/executors/host-exec.md
@@ -1,0 +1,51 @@
+# Host Exec
+
+The host exec executor runs commands on the host machine via the bridge server. It supports foreground and background execution with process management, similar to [Dev Session](dev-session.md) but running on the host instead of in a container.
+
+## Requirements
+
+- Bridge service running (`bridge.enabled: true` in `agent.yaml`)
+
+## Tools
+
+### `host_exec`
+
+Run a command on the host.
+
+```json
+{
+  "tool": "host_exec",
+  "args": {
+    "command": "ls -la /tmp",
+    "timeout": 60,
+    "env": {"MY_VAR": "value"}
+  }
+}
+```
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `command` | Yes | — | Command to execute |
+| `background` | No | `false` | Run in background |
+| `workdir` | No | — | Working directory |
+| `timeout` | No | `300` | Timeout in seconds |
+| `env` | No | — | Environment variables (JSON object) |
+
+### `host_process`
+
+Manage a running background process. Same interface as [`dev_process`](dev-session.md#dev_process).
+
+### `host_sessions`
+
+List all active host sessions. No parameters.
+
+## Security
+
+Environment variables passed via `env` are validated. The following patterns are blocked to prevent injection attacks:
+
+- Library injection: `LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_*`
+- Shell injection: `BASH_ENV`, `ENV`, `CDPATH`
+- Interpreter injection: `PYTHONPATH`, `NODE_OPTIONS`, `PERL5OPT`, `RUBYOPT`
+- Token leakage: `BRIDGE_TOKEN_*`, `BASH_FUNC_*`
+
+**Bridge endpoints**: `/exec`, `/process`, `/sessions`

--- a/docs/executors/imessage.md
+++ b/docs/executors/imessage.md
@@ -24,7 +24,10 @@ bluebubbles:
 |-----------|----------|-------------|
 | `action` | yes | `get_recent_messages`, `send_message`, `send_reaction`, or `get_chats` |
 | `chat_id` | varies | Chat ID for message operations |
-| `limit` | no | Maximum messages to return (default: 25) |
+| `limit` | no | Maximum messages to return (default: 20) |
+| `after_date` | no | Only return messages after this date |
+| `message_guid` | no | Message GUID for reactions |
+| `reaction` | no | Reaction type for `send_reaction` |
 
 ### Safety Limits
 
@@ -34,22 +37,17 @@ Built-in safety measures: hard caps on message count (50), message length (2000 
 
 Sends and reads iMessages via the host bridge. Uses the `imsg` CLI tool for macOS integration, providing an alternative to BlueBubbles.
 
-### Configuration
+### Tools
 
-```yaml
-imessage_bridge:
-  args:
-    action: "get_recent"     # get_recent, send_message, get_chats
-    limit: "25"
-    chat_id: "chat123"
-```
+The executor exposes one tool via the skill registry:
 
-### Parameters
+**`imessage_send`** — Send an iMessage.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `action` | yes | `get_recent`, `send_message`, or `get_chats` |
-| `limit` | no | Maximum messages to return (default: 25) |
-| `chat_id` | varies | Chat ID for message operations |
+| `recipient` | yes | Phone number or email of recipient |
+| `text` | yes | Message text |
+
+The underlying executor also supports `recent` (get recent messages) and `chats` (list chats) actions via direct invocation with `limit` (default: 20).
 
 See [Host Bridge](../deployment/host-bridge.md) for information on the bridge server that powers this executor.

--- a/docs/executors/index.md
+++ b/docs/executors/index.md
@@ -22,6 +22,10 @@ Executors are isolated, stateless data fetchers that run with minimal credential
 | file_ops | Host filesystem (scoped) | LLM, other credentials |
 | [exec](exec.md) | Host filesystem (scoped) | LLM, other credentials |
 | [exec_interactive](exec-interactive.md) | Network access (SSH, REPLs) | LLM, other credentials |
+| [clipboard](clipboard.md) | Bridge HTTP token (scoped) | LLM, other credentials |
+| [tts](tts.md) | ElevenLabs / OpenAI API key | LLM, other credentials |
+| [dev_session](dev-session.md) | None (containerized) | LLM, other credentials |
+| [host_exec](host-exec.md) | Bridge HTTP token (scoped) | LLM, other credentials |
 
 ## How Executors Run
 

--- a/docs/executors/tts.md
+++ b/docs/executors/tts.md
@@ -1,0 +1,59 @@
+# Text-to-Speech (TTS)
+
+The TTS executor synthesizes speech from text using multiple backends.
+
+## Backends
+
+| Backend | API Key Required | Default Voice | Formats |
+|---------|-----------------|---------------|---------|
+| **OpenAI** | `OPENAI_API_KEY` | nova | mp3, wav, ogg |
+| **ElevenLabs** | `ELEVENLABS_API_KEY` | Rachel | mp3, wav, ogg |
+| **Local** (pyttsx3) | None | System default | wav |
+
+## Tools
+
+### `synthesize_speech`
+
+Convert text to an audio file.
+
+```json
+{
+  "tool": "synthesize_speech",
+  "args": {
+    "text": "Good morning. Here is your briefing.",
+    "backend": "openai",
+    "voice": "nova",
+    "output_format": "mp3"
+  }
+}
+```
+
+**Parameters:**
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `text` | Yes | — | Text to synthesize (max 5000 chars) |
+| `backend` | No | `openai` | `openai`, `elevenlabs`, or `local` |
+| `voice` | No | Backend default | Voice name |
+| `output_format` | No | `mp3` | `mp3`, `wav`, or `ogg` |
+| `output_path` | No | Auto-generated | Custom output file path |
+
+**Returns:** JSON with `audio_path`, `backend`, `voice`, `format`, `cached`, and `chars`.
+
+## Configuration
+
+Environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TTS_BACKEND` | `openai` | Default backend |
+| `TTS_VOICE` | Backend default | Default voice |
+| `TTS_OUTPUT_FORMAT` | `mp3` | Default output format |
+| `TTS_OUTPUT_DIR` | `/tmp/creel_tts` | Cache directory |
+| `TTS_MAX_CHARS` | `5000` | Max text length |
+| `TTS_MODEL` | `eleven_turbo_v2` | ElevenLabs model ID |
+
+## Features
+
+- **Caching**: Audio files are cached using a SHA256 key derived from text, voice, backend, and format. Repeated requests return the cached file.
+- **Rate limiting**: Max 20 requests per minute per backend.

--- a/docs/getting-started/google-services.md
+++ b/docs/getting-started/google-services.md
@@ -3,7 +3,7 @@
 All Google services use the same OAuth2 client credentials (client ID + client secret from a single GCP project) but obtain **separate refresh tokens** with different scopes. This means:
 
 - One `client_secret.json` file works for all services
-- Each service gets its own `.env` file (e.g. `secrets/gcal.env`, `secrets/gmail_send.env`)
+- Each service gets its own `.env` file (e.g. `secrets/gcal.env`, `secrets/gmail_send.env`), encrypted to `.env.enc` at rest
 - Each refresh token is scoped to a single API permission
 - Revoking one token doesn't affect the others
 
@@ -34,9 +34,12 @@ python scripts/setup-google-oauth.py --encrypt-all
 | Gmail (modify) | `gmail_modify` | `gmail.modify` |
 | Google Drive (read) | `drive` | `drive.readonly` |
 | Google Drive (write) | `drive_write` | `drive.file` |
-| Google Docs | `google_docs` | `documents`, `documents.readonly` |
-| Google Sheets | `google_sheets` | `spreadsheets`, `spreadsheets.readonly` |
-| Google Slides | `google_slides` | `presentations`, `presentations.readonly` |
+| Google Docs (read) | `docs_read` | `documents.readonly` |
+| Google Docs (write) | `docs_write` | `documents` |
+| Google Sheets (read) | `sheets_read` | `spreadsheets.readonly` |
+| Google Sheets (write) | `sheets_write` | `spreadsheets` |
+| Google Slides (read) | `slides_read` | `presentations.readonly` |
+| Google Slides (write) | `slides_write` | `presentations` |
 
 ## GCP Project Setup
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -6,7 +6,7 @@ Get Creel running in 5 minutes. By the end you'll have a personal AI agent respo
 
 | Tool | What it's for | Install |
 |------|--------------|---------|
-| Python 3.11+ | Runtime | `pyenv install 3.12.12` |
+| Python 3.11+ | Runtime | `pyenv install 3.12.11` |
 | [age](https://github.com/FiloSottile/age) | Secrets encryption | `brew install age` |
 | Docker | Container isolation (optional) | [docker.com](https://docs.docker.com/get-docker/) |
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -69,11 +69,13 @@ creel init
 
 The wizard will walk you through:
 
-1. **LLM provider** — Anthropic, OpenAI, or Ollama (local)
+1. **LLM provider** — Anthropic, OpenAI, Google (Gemini), or Ollama (local)
 2. **API key** — entered securely via hidden prompt, validated inline
 3. **Model** — defaults to the provider's recommended model
-4. **Channel** — Telegram, iMessage, or CLI-only
-5. **Features** — media processing, guardian security pipeline
+4. **Tools** — multi-select from the available tool catalog
+5. **Channel** — Telegram, iMessage, WhatsApp, or CLI-only
+6. **Security** — Guardian pipeline (policy engine, audit logging)
+7. **Media processing** — images and voice (optional)
 
 Your API key is encrypted with [age](https://github.com/FiloSottile/age) and stored in `~/.creel/secrets/` — plaintext never touches disk.
 
@@ -156,7 +158,7 @@ To remove: `creel daemon uninstall`
 
     ---
 
-    Define tools in `agent.yaml` — calendar, email, web search, and more. Each runs in its own isolated Docker container.
+    Define skills in `agent.yaml` — calendar, email, web search, and more. Each runs in its own isolated Docker container.
 
     [:octicons-arrow-right-24: Agent Configuration](../configuration/agent-config.md)
 

--- a/docs/getting-started/telegram.md
+++ b/docs/getting-started/telegram.md
@@ -85,7 +85,7 @@ If using webhook mode:
 Configure access in `agent.yaml`:
 
 ```yaml
-allowed_senders:          # required — at least one entry
+allowed_senders:          # required when sender_policy is "closed" (default)
   - "123456789"          # numeric user ID
   - "@yourusername"      # @username (case-sensitive)
 allowed_chats:
@@ -103,7 +103,31 @@ allowed_senders:
   - "$TELEGRAM_ALLOWED_SENDER"
 ```
 
-`allowed_senders` is mandatory — the channel will refuse to start without at least one entry. Outbound messages are also restricted to verified senders and listed chats. When a sender is identified by `@username`, their numeric chat ID is dynamically registered on first inbound message so that replies work.
+`allowed_senders` is mandatory when `sender_policy` is `closed` (the default) — the channel will refuse to start without at least one entry. Outbound messages are also restricted to verified senders and listed chats. When a sender is identified by `@username`, their numeric chat ID is dynamically registered on first inbound message so that replies work.
+
+### Sender Policy
+
+The `sender_policy` field controls how the bot handles messages from unknown senders:
+
+```yaml
+sender_policy: closed       # default — only allowed_senders can interact
+# sender_policy: allowlist  # same as closed, but with SenderGate for approval flows
+# sender_policy: open       # accept messages from anyone (allowed_senders optional)
+```
+
+| Policy | Behavior |
+|--------|----------|
+| `closed` | Only `allowed_senders` can interact. All others are silently ignored. |
+| `allowlist` | Unknown senders are held for owner approval. Enables `/approve` and `/deny` commands. |
+| `open` | Accept messages from any sender. `allowed_senders` is optional. |
+
+Additional fields for `allowlist`/`open` policies:
+
+| Field | Description |
+|-------|-------------|
+| `auto_approve_senders` | Automatically approve new senders without owner confirmation |
+| `notify_owner` | Send a notification to the owner when a new sender requests access |
+| `owner` | Explicit owner ID (defaults to first entry in `allowed_senders`) |
 
 ## 7. Group Chat
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ A secure LLM task runner and personal AI assistant that separates credential-bea
 - **Scheduled tasks** — Cron-based scheduling for recurring tasks like morning briefings and email digests.
 - **Interactive agent mode** — Chat via CLI (with TUI) or iMessage with full tool calling support.
 - **Guardian security pipeline** — Multi-stage input screening and action validation with prompt-injection detection, policy enforcement, and audit logging.
-- **27+ executors** — Google Calendar, Gmail, Drive, Docs, Sheets, Slides, Apple Notes, Reminders, Things 3, iMessage, Telegram, WhatsApp, Notion, GitHub, web search, browser automation, and more.
+- **30+ integrations** — Google Calendar, Gmail, Drive, Docs, Sheets, Slides, Apple Notes, Reminders, Things 3, iMessage, Notion, GitHub, web search, browser automation, clipboard, text-to-speech, and more. Channels include Telegram, WhatsApp, and webhooks.
 - **Container isolation** — Production mode runs executors in Docker containers with read-only filesystems, dropped capabilities, and memory/CPU limits.
 - **Secrets management** — age-encrypted secrets decrypted at runtime; the LLM never touches credential files.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -50,14 +50,44 @@ By default, `creel init` launches an interactive wizard that validates credentia
 | `--migrate` | Copy existing repo-based config into `~/.creel/` |
 | `--repo-root PATH` | Repo root to migrate from (default: current directory) |
 | `--non-interactive` | Skip interactive wizard, use CLI flags below |
-| `--provider TYPE` | LLM provider: `anthropic`, `openai`, `ollama` |
+| `--provider TYPE` | LLM provider: `anthropic`, `openai`, `google`, `ollama` |
 | `--api-key KEY` | LLM API key |
 | `--model NAME` | LLM model name (defaults per provider) |
-| `--channel TYPE` | Channel: `telegram`, `imessage`, `none` |
+| `--channel TYPE` | Channel: `telegram`, `imessage`, `whatsapp`, `none` |
 | `--bot-token TOKEN` | Telegram bot token |
 | `--allowed-senders LIST` | Comma-separated list of allowed Telegram sender usernames |
 | `--enable-media` | Enable media processing (images, voice) |
+| `--tools LIST` | Comma-separated list of tools to enable |
 | `--no-guardian` | Disable guardian security pipeline |
+
+## Encrypt Command
+
+```bash
+creel encrypt <file> [options]
+```
+
+Encrypt a plaintext `.env` file with age.
+
+| Option | Description |
+|--------|-------------|
+| `--recipient PATH` | Path to age public key file (default: `~/.age/key.pub`) |
+| `--output PATH` | Custom output path (default: `<file>.enc`) |
+| `--delete` | Delete plaintext file after encryption |
+
+## Cron Commands
+
+```bash
+creel cron <subcommand> [options]
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | List all cron jobs |
+| `add` | Add a new cron job |
+| `edit <id>` | Edit an existing cron job |
+| `remove <id>` | Remove a cron job |
+| `run <id>` | Trigger a cron job immediately |
+| `runs <id>` | Show run history for a cron job |
 
 ## Daemon Commands
 
@@ -65,6 +95,7 @@ By default, `creel init` launches an interactive wizard that validates credentia
 |---------|-------------|
 | `creel daemon start` | Start daemon (`launchd` if installed, otherwise detached process) |
 | `creel daemon stop` | Stop daemon (or unload `launchd` service) |
+| `creel daemon restart` | Restart daemon |
 | `creel daemon status` | Show daemon process, API, and `launchd` status |
 | `creel daemon install` | Install daemon as a persistent `launchd` service (macOS) |
 | `creel daemon uninstall` | Uninstall daemon `launchd` service (macOS) |

--- a/docs/reference/project-structure.md
+++ b/docs/reference/project-structure.md
@@ -9,7 +9,8 @@ creel/
 ├── src/
 │   ├── bridge/            # Host bridge server for macOS tool integration
 │   │   ├── server.py      # FastAPI bridge server (localhost:8099)
-│   │   └── browser.py     # Browser control
+│   │   ├── browser.py     # Browser control (Playwright)
+│   │   └── process_manager.py # Background process management
 │   ├── creel/
 │   │   ├── cli.py         # CLI entry point (`creel` command)
 │   │   ├── agent.py       # Agent loop: LLM -> tool_use -> execute -> loop
@@ -37,8 +38,25 @@ creel/
 │   │   ├── media.py       # Media handling
 │   │   ├── init.py        # `creel init` wizard
 │   │   ├── paths.py       # Path constants
+│   │   ├── context.py     # Context pruning / token management
+│   │   ├── config_reload.py # Hot-reload agent config
+│   │   ├── safety.py      # Destructive command blocklist
+│   │   ├── knowledge_base.py # Knowledge base indexing
+│   │   ├── rate_limiter.py # LLM API rate limiting
+│   │   ├── pairing.py     # Device pairing (TOTP)
+│   │   ├── tool_cache.py  # Tool result caching
+│   │   ├── providers/     # LLM provider backends (Anthropic, OpenAI, Google, Ollama)
+│   │   ├── skills/        # Skill registry and definitions
+│   │   ├── monitors/      # Proactive monitor system
+│   │   ├── services/      # Media storage, transcription, vision
 │   │   ├── channels/
 │   │   │   ├── base.py        # Channel ABC
+│   │   │   ├── plugin.py      # Plugin metadata and capabilities
+│   │   │   ├── registry.py    # Channel discovery and registration
+│   │   │   ├── sender_gate.py # Sender approval/deny access control
+│   │   │   ├── sender_store.py# Persistent sender state
+│   │   │   ├── message.py     # Message models
+│   │   │   ├── mixins/        # Reusable channel mixins (polling, media, retry, etc.)
 │   │   │   ├── imessage.py    # iMessage channel (polls chat.db)
 │   │   │   ├── bluebubbles.py # BlueBubbles iMessage channel (REST API)
 │   │   │   ├── telegram.py    # Telegram channel
@@ -47,16 +65,27 @@ creel/
 │   │   │   ├── whatsapp_bridge.py # WhatsApp bridge
 │   │   │   └── webhook.py     # Webhook channel
 │   │   ├── cron/          # Cron scheduling subsystem
+│   │   │   ├── models.py  # Cron data models
 │   │   │   ├── manager.py # Cron job management
 │   │   │   ├── executor.py# Cron job execution
 │   │   │   ├── delivery.py# Result delivery
 │   │   │   ├── store.py   # Job persistence
 │   │   │   └── tool.py    # Cron tool definitions
 │   │   ├── daemon/        # Background daemon with REST API
-│   │   │   ├── api.py     # FastAPI app (tasks, cron, dashboard, auth, logs)
+│   │   │   ├── api.py     # FastAPI app (main routes)
+│   │   │   ├── api_auth.py    # Authentication endpoints
+│   │   │   ├── api_chat.py    # Chat/messaging endpoints
+│   │   │   ├── api_config.py  # Config endpoints
+│   │   │   ├── api_cron.py    # Cron management endpoints
+│   │   │   ├── api_dashboard.py # Dashboard endpoints
+│   │   │   ├── api_files.py   # File management endpoints
+│   │   │   ├── api_logs.py    # Log viewing endpoints
+│   │   │   ├── api_pairing.py # Device pairing endpoints
+│   │   │   ├── api_tasks.py   # Task management endpoints
 │   │   │   ├── service.py # Daemon service lifecycle
 │   │   │   ├── client.py  # Daemon API client
-│   │   │   └── contracts.py # API request/response models
+│   │   │   ├── contracts.py # API request/response models
+│   │   │   └── watcher.py # File/config watcher
 │   │   └── subagents/     # Sub-agent delegation
 │   │       ├── manager.py # Sub-agent orchestration
 │   │       ├── executor.py# Sub-agent execution
@@ -87,7 +116,13 @@ creel/
 │   │   ├── apple_reminders/   # Apple Reminders (bridge)
 │   │   ├── things/            # Things 3 (bridge)
 │   │   ├── imessage_bridge/   # iMessage (bridge)
-│   │   └── bluebubbles/       # BlueBubbles iMessage relay
+│   │   ├── bluebubbles/       # BlueBubbles iMessage relay
+│   │   ├── clipboard/         # macOS clipboard (bridge)
+│   │   ├── tts/               # Text-to-speech (ElevenLabs, OpenAI, local)
+│   │   ├── dev_session/       # Containerized dev sessions
+│   │   ├── host_exec/         # Host command execution (bridge)
+│   │   ├── exec_interactive/  # Interactive PTY sessions
+│   │   └── base/              # Shared base Docker image
 │   └── guardian/
 │       ├── core.py            # Guardian class (screen_input, validate_action)
 │       ├── types.py           # Data models and config
@@ -97,16 +132,19 @@ creel/
 │       ├── policy.py          # YAML policy engine (allow/review/deny/auto_approve)
 │       ├── credential_scanner.py # Credential detection
 │       ├── drift.py           # Input drift detection
-│       └── audit.py           # Privacy-preserving JSONL audit logger
+│       ├── audit.py           # Privacy-preserving JSONL audit logger
+│       ├── network.py         # Network policy enforcement
+│       ├── overrides.py       # Temporary allow/deny overrides
+│       └── pipeline.py        # Pipeline orchestration (parallel/sequential checks)
 ├── policies/
 │   └── default.yaml       # Default tool action policies
 ├── tasks/                 # Task definitions (YAML)
-├── llm/                   # Containerized LLM runner + Dockerfile
+├── src/llm/               # Containerized LLM runner + Dockerfile
 ├── dashboard/             # Web dashboard for monitoring
 ├── scripts/
 │   ├── encrypt-secret.sh    # age encryption helper
 │   └── setup-google-oauth.py# Google OAuth setup
 ├── secrets/               # Encrypted .env files (gitignored)
 ├── workspace/             # Agent workspace memory (gitignored)
-└── tests/                 # Pytest suite (120+ test files)
+└── tests/                 # Pytest suite (160+ test files)
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,12 +36,15 @@ nav:
     - Authentication: getting-started/authentication.md
     - Google Services Setup: getting-started/google-services.md
     - OpenClaw Migration: getting-started/openclaw-migration.md
+    - Telegram: getting-started/telegram.md
   - Architecture:
     - Overview: architecture/overview.md
     - Agent Mode: architecture/agent-mode.md
     - Channels: architecture/channels.md
     - Device Pairing: architecture/device-pairing.md
     - Guardian Security: architecture/guardian.md
+    - Browser Automation: architecture/browser.md
+    - Cron Scheduling: architecture/cron.md
   - Configuration:
     - Task Definitions: configuration/tasks.md
     - Agent Configuration: configuration/agent-config.md
@@ -60,6 +63,11 @@ nav:
     - Web Search & Fetch: executors/web.md
     - Shell Exec: executors/exec.md
     - Interactive Shell Exec: executors/exec-interactive.md
+    - GitHub: executors/github.md
+    - Clipboard: executors/clipboard.md
+    - Text-to-Speech: executors/tts.md
+    - Dev Session: executors/dev-session.md
+    - Host Exec: executors/host-exec.md
   - Deployment:
     - Container Mode: deployment/containers.md
     - Host Bridge: deployment/host-bridge.md

--- a/site/architecture/index.html
+++ b/site/architecture/index.html
@@ -1,0 +1,389 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Architecture — Creel</title>
+  <meta name="description" content="How Creel enforces per-tool isolation, Guardian safety, and credential separation to keep your AI agent secure.">
+  <link rel="stylesheet" href="../styles.css">
+  <link rel="icon" href="../assets/creel-logo.jpg">
+  <style>
+    .arch-page { padding: 120px 24px 80px; }
+    .arch-page h1 { font-size: 2.4rem; font-weight: 800; margin-bottom: 16px; }
+    .arch-page .lead { color: var(--text-dim); font-size: 1.1rem; max-width: 640px; margin-bottom: 48px; line-height: 1.7; }
+
+    /* Isolation table */
+    .iso-table { width: 100%; border-collapse: collapse; margin-bottom: 48px; }
+    .iso-table th, .iso-table td {
+      text-align: left; padding: 12px 16px; border-bottom: 1px solid var(--border); font-size: 0.95rem;
+    }
+    .iso-table th { color: var(--text-dim); font-weight: 600; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; }
+    .iso-table td:first-child { font-weight: 600; white-space: nowrap; }
+    .iso-table .has { color: var(--green); }
+    .iso-table .no { color: var(--red); }
+
+    /* Full diagram */
+    .diagram-section { padding: 60px 0; }
+    .diagram-section h2 { font-size: 1.8rem; margin-bottom: 40px; }
+
+    .full-diagram {
+      display: grid; grid-template-columns: 1fr; gap: 24px;
+      max-width: 800px; margin: 0 auto;
+    }
+
+    .diagram-row {
+      display: flex; align-items: stretch; gap: 16px; justify-content: center; flex-wrap: wrap;
+    }
+
+    .diagram-box {
+      background: var(--surface); border: 2px solid var(--border); border-radius: 12px;
+      padding: 24px; text-align: center; flex: 1; min-width: 180px; max-width: 320px;
+    }
+    .diagram-box h4 { font-size: 1rem; margin-bottom: 6px; }
+    .diagram-box p { color: var(--text-dim); font-size: 0.85rem; line-height: 1.5; }
+    .diagram-box .items { color: var(--text-dim); font-size: 0.8rem; margin-top: 8px; line-height: 1.6; }
+
+    .diagram-box.channels { border-color: var(--green); }
+    .diagram-box.orchestrator { border-color: var(--blue); }
+    .diagram-box.guardian { border-color: var(--accent); }
+    .diagram-box.executors { border-color: var(--red); }
+    .diagram-box.bridge { border-color: var(--yellow); }
+    .diagram-box.llm { border-color: var(--purple); }
+
+    .diagram-connector {
+      text-align: center; color: var(--text-dim); font-size: 1.2rem; padding: 4px 0;
+    }
+
+    /* Guardian detail */
+    .guardian-section { padding: 60px 0; background: var(--bg2); }
+    .guardian-section h2 { font-size: 1.8rem; margin-bottom: 40px; text-align: center; }
+    .guardian-layers {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 20px; max-width: 700px; margin: 0 auto;
+    }
+    .layer-card {
+      background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+      padding: 24px; position: relative;
+    }
+    .layer-card .layer-num {
+      position: absolute; top: 12px; right: 16px; font-size: 0.75rem;
+      font-weight: 700; color: var(--text-dim); font-family: var(--mono);
+    }
+    .layer-card h4 { margin-bottom: 6px; }
+    .layer-card p { color: var(--text-dim); font-size: 0.9rem; line-height: 1.5; }
+
+    .layer-card.l1 h4 { color: var(--blue); }
+    .layer-card.l2 h4 { color: var(--purple); }
+    .layer-card.l3 h4 { color: var(--accent); }
+    .layer-card.l4 h4 { color: var(--green); }
+
+    /* Executor grid */
+    .executor-section { padding: 60px 0; }
+    .executor-section h2 { font-size: 1.8rem; margin-bottom: 12px; }
+    .executor-section .lead { margin-bottom: 32px; }
+    .exec-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 16px; }
+    .exec-card {
+      background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+      padding: 20px;
+    }
+    .exec-card h4 { font-size: 0.95rem; margin-bottom: 4px; }
+    .exec-card p { color: var(--text-dim); font-size: 0.8rem; line-height: 1.4; }
+    .exec-card .exec-icon { font-size: 1.4rem; margin-bottom: 8px; }
+
+    /* Key insight callout */
+    .callout {
+      background: rgba(249,115,22,0.08); border: 1px solid rgba(249,115,22,0.2);
+      border-radius: 10px; padding: 20px 24px; margin: 40px 0; font-size: 0.95rem;
+      line-height: 1.6;
+    }
+    .callout strong { color: var(--accent); }
+
+    @media (max-width: 700px) {
+      .diagram-row { flex-direction: column; align-items: center; }
+      .diagram-box { max-width: 100%; }
+      .guardian-layers { grid-template-columns: 1fr; }
+      .arch-page h1 { font-size: 1.8rem; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Nav -->
+  <nav class="nav">
+    <div class="nav-inner">
+      <a href="../" class="nav-logo">
+        <img src="../assets/creel-logo.jpg" alt="Creel" width="32" height="32">
+        <span>Creel</span>
+      </a>
+      <div class="nav-links">
+        <a href="../#features">Features</a>
+        <a href="./">Architecture</a>
+        <a href="../#quickstart">Get Started</a>
+        <a href="https://github.com/Creel-ai/creel" class="btn btn-sm" target="_blank">GitHub ↗</a>
+      </div>
+      <button class="nav-toggle" aria-label="Menu" onclick="document.querySelector('.nav-links').classList.toggle('open')">☰</button>
+    </div>
+  </nav>
+
+  <!-- Header -->
+  <section class="arch-page">
+    <div class="container">
+      <h1>Architecture</h1>
+      <p class="lead">Creel enforces <strong>per-tool isolation</strong> — each executor runs in its own container with only the credentials it needs. The LLM never sees secrets. A compromised tool can't reach other tools' data.</p>
+
+      <!-- Isolation table -->
+      <table class="iso-table">
+        <thead>
+          <tr><th>Component</th><th>Has access to</th><th>Does NOT have</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Each executor</td>
+            <td class="has">Only its own credential (one OAuth scope, one API key)</td>
+            <td class="no">LLM, other tools' credentials</td>
+          </tr>
+          <tr>
+            <td>Bridge executors</td>
+            <td class="has">Scoped HTTP token for one macOS app</td>
+            <td class="no">LLM, other bridge endpoints</td>
+          </tr>
+          <tr>
+            <td>LLM Runner</td>
+            <td class="has">Anthropic API key only</td>
+            <td class="no">Any tool credentials</td>
+          </tr>
+          <tr>
+            <td>Orchestrator</td>
+            <td class="has">All secrets, LLM output</td>
+            <td class="no">Untrusted external input</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout">
+        <strong>Key insight:</strong> Even if prompt injection occurs (e.g., via a calendar event title), the LLM container has nothing to exfiltrate except its own API key. A compromised executor can only access its one scoped credential — not your email, not your files, not your messages.
+      </div>
+    </div>
+  </section>
+
+  <!-- System Diagram -->
+  <section class="diagram-section" style="background: var(--bg2);">
+    <div class="container">
+      <h2>System Diagram</h2>
+      <div class="full-diagram">
+
+        <!-- Channels -->
+        <div class="diagram-row">
+          <div class="diagram-box channels">
+            <h4>Channels</h4>
+            <p>Input from users</p>
+            <div class="items">TUI / CLI &middot; iMessage &middot; Telegram &middot; WhatsApp &middot; Webhooks</div>
+          </div>
+        </div>
+
+        <div class="diagram-connector">&#8595;</div>
+
+        <!-- Orchestrator -->
+        <div class="diagram-row">
+          <div class="diagram-box orchestrator">
+            <h4>Orchestrator</h4>
+            <p>Scheduler, agent loop, prompt builder, output router</p>
+          </div>
+        </div>
+
+        <div class="diagram-connector">&#8595;</div>
+
+        <!-- Guardian -->
+        <div class="diagram-row">
+          <div class="diagram-box guardian">
+            <h4>Guardian Pipeline</h4>
+            <p>4-layer safety gate — every tool call passes through here</p>
+          </div>
+        </div>
+
+        <div class="diagram-connector">&#8595; approved</div>
+
+        <!-- Executors + Bridge side by side -->
+        <div class="diagram-row">
+          <div class="diagram-box executors">
+            <h4>Docker Executors</h4>
+            <p>Isolated containers</p>
+            <div class="items">Google Suite &middot; Notion &middot; GitHub &middot; Search &middot; Shell &middot; TTS &middot; Dev Sessions</div>
+          </div>
+          <div class="diagram-box bridge">
+            <h4>Host Bridge</h4>
+            <p>macOS native access</p>
+            <div class="items">Notes &middot; Reminders &middot; Things 3 &middot; iMessage &middot; Clipboard</div>
+          </div>
+        </div>
+
+        <div class="diagram-connector">&#8595; JSON results</div>
+
+        <!-- LLM -->
+        <div class="diagram-row">
+          <div class="diagram-box llm">
+            <h4>LLM Container</h4>
+            <p>Claude — has Anthropic API key only, no tool credentials</p>
+          </div>
+        </div>
+
+        <div class="diagram-connector">&#8595; response</div>
+
+        <!-- Output -->
+        <div class="diagram-row">
+          <div class="diagram-box channels">
+            <h4>Output</h4>
+            <p>Routed back through channels to you</p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- Guardian Pipeline Detail -->
+  <section class="guardian-section">
+    <div class="container">
+      <h2>Guardian Pipeline</h2>
+      <div class="guardian-layers">
+        <div class="layer-card l1">
+          <span class="layer-num">01</span>
+          <h4>Fast Classifier</h4>
+          <p>DeBERTa/ONNX model provides instant risk scoring on every input. Catches obvious prompt injection attempts in milliseconds.</p>
+        </div>
+        <div class="layer-card l2">
+          <span class="layer-num">02</span>
+          <h4>LLM Judge</h4>
+          <p>Claude Haiku performs a deeper contextual safety review. Catches subtle attacks that bypass pattern matching.</p>
+        </div>
+        <div class="layer-card l3">
+          <span class="layer-num">03</span>
+          <h4>Policy Engine</h4>
+          <p>YAML-defined rules enforce your explicit constraints. Allow, review, or deny tools by pattern. Block dangerous shell commands.</p>
+        </div>
+        <div class="layer-card l4">
+          <span class="layer-num">04</span>
+          <h4>Coherence Check</h4>
+          <p>Validates that the requested action matches the user's original intent. Detects drift between what was asked and what's being executed.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Executor Overview -->
+  <section class="executor-section">
+    <div class="container">
+      <h2>30+ Executors</h2>
+      <p class="lead">Each executor is a self-contained package with its own Dockerfile. In production, every one runs in an isolated container with <code>--read-only</code>, <code>--cap-drop=ALL</code>, memory/CPU limits, and a 60-second timeout.</p>
+      <div class="exec-grid">
+        <div class="exec-card">
+          <div class="exec-icon">📅</div>
+          <h4>Google Calendar</h4>
+          <p>Read and write calendar events via OAuth</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">📧</div>
+          <h4>Gmail</h4>
+          <p>Read, send, and manage email with scoped access</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">📁</div>
+          <h4>Google Drive</h4>
+          <p>Read and write files in Drive</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">📄</div>
+          <h4>Docs / Sheets / Slides</h4>
+          <p>Full Google Workspace document access</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">💬</div>
+          <h4>iMessage</h4>
+          <p>Send and receive via BlueBubbles or bridge</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">📝</div>
+          <h4>Apple Notes</h4>
+          <p>Search, read, and create notes</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">✅</div>
+          <h4>Reminders &amp; Things</h4>
+          <p>Apple Reminders and Things 3 task management</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">📋</div>
+          <h4>Clipboard</h4>
+          <p>Read and write macOS clipboard via bridge</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">🔍</div>
+          <h4>Brave Search</h4>
+          <p>Web search via Brave Search API</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">🌐</div>
+          <h4>Browser</h4>
+          <p>Playwright-based web automation</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">🌤</div>
+          <h4>Weather</h4>
+          <p>Weather forecasts with no credentials</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">🔗</div>
+          <h4>Fetch URL</h4>
+          <p>Retrieve and parse web page content</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">📓</div>
+          <h4>Notion</h4>
+          <p>Read and write Notion pages and databases</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">🐙</div>
+          <h4>GitHub</h4>
+          <p>Issues, PRs, repos via GitHub CLI</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">⚙️</div>
+          <h4>Shell Exec</h4>
+          <p>Sandboxed command execution on mounted paths</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">🛠</div>
+          <h4>Dev Session</h4>
+          <p>Long-lived containerized dev environments</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">🖥</div>
+          <h4>Host Exec</h4>
+          <p>Run commands on the host via bridge</p>
+        </div>
+        <div class="exec-card">
+          <div class="exec-icon">🔊</div>
+          <h4>Text-to-Speech</h4>
+          <p>ElevenLabs, OpenAI, or local TTS backends</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="container footer-inner">
+      <div class="footer-brand">
+        <img src="../assets/creel-logo.jpg" alt="Creel" width="28" height="28">
+        <span>Creel</span>
+        <span class="dim">&middot; MIT License</span>
+      </div>
+      <div class="footer-links">
+        <a href="https://github.com/Creel-ai/creel" target="_blank">GitHub</a>
+        <a href="https://discord.gg/wGym2meFFZ" target="_blank">Discord</a>
+        <a href="https://twitter.com/creelai" target="_blank">Twitter</a>
+      </div>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Creel — The AI Agent That Doesn't Trust Its Own Tools</title>
-  <meta name="description" content="Secure, self-hosted personal AI agent framework with 27+ integrations, per-tool Docker isolation, and a Guardian safety pipeline.">
+  <meta name="description" content="Secure, self-hosted personal AI agent framework with 30+ integrations, per-tool Docker isolation, and a Guardian safety pipeline.">
   <link rel="stylesheet" href="styles.css">
   <link rel="icon" href="assets/creel-logo.jpg">
 </head>
@@ -19,7 +19,7 @@
       </a>
       <div class="nav-links">
         <a href="#features">Features</a>
-        <a href="#architecture">Architecture</a>
+        <a href="architecture/">Architecture</a>
         <a href="#quickstart">Get Started</a>
         <a href="https://github.com/Creel-ai/creel" class="btn btn-sm" target="_blank">GitHub ↗</a>
       </div>
@@ -32,7 +32,7 @@
     <div class="hero-inner">
       <img src="assets/creel-logo.jpg" alt="Creel logo" class="hero-logo">
       <h1>The only AI agent that doesn't trust its own tools.</h1>
-      <p class="hero-sub">A secure, self-hosted personal AI agent framework with 27+ integrations. Every tool runs in its own Docker container. Every action passes through a Guardian safety pipeline. You stay in control.</p>
+      <p class="hero-sub">A secure, self-hosted personal AI agent framework with 30+ integrations. Every tool runs in its own Docker container. Every action passes through a Guardian safety pipeline. You stay in control.</p>
       <div class="hero-actions">
         <a href="#quickstart" class="btn btn-primary">Get Started</a>
         <a href="https://github.com/Creel-ai/creel" class="btn btn-outline" target="_blank">View on GitHub</a>
@@ -94,8 +94,8 @@
 
         <div class="feature-card">
           <div class="feature-icon">🔌</div>
-          <h3>27+ Integrations</h3>
-          <p>Google Workspace, GitHub, Notion, Apple Notes &amp; Reminders, Things 3, Brave Search, browser automation, shell execution, and more — all containerized.</p>
+          <h3>30+ Integrations</h3>
+          <p>Google Workspace, GitHub, Notion, Apple Notes &amp; Reminders, Things 3, Brave Search, browser automation, clipboard, text-to-speech, shell execution, and more — all containerized.</p>
         </div>
 
       </div>
@@ -159,7 +159,7 @@
 <span class="c-comment"># Clone and set up</span>
 <span class="c-prompt">$</span> git clone https://github.com/Creel-ai/creel.git
 <span class="c-prompt">$</span> cd creel
-<span class="c-prompt">$</span> pyenv install 3.12.11
+<span class="c-prompt">$</span> pyenv install 3.12.12
 <span class="c-prompt">$</span> uv venv && source .venv/bin/activate
 <span class="c-prompt">$</span> uv pip install -e ".[dev]"
 
@@ -167,7 +167,7 @@
 <span class="c-prompt">$</span> export ANTHROPIC_API_KEY=sk-ant-...
 <span class="c-prompt">$</span> creel daemon start
 
-<span class="c-output">🧺 Creel daemon running. Tools loaded: 27. Guardian: active.</span>
+<span class="c-output">🧺 Creel daemon running. Tools loaded: 32. Guardian: active.</span>
 
 <span class="c-comment"># Or run a task directly</span>
 <span class="c-prompt">$</span> creel run morning-briefing</code></pre>

--- a/site/index.html
+++ b/site/index.html
@@ -159,12 +159,14 @@
 <span class="c-comment"># Clone and set up</span>
 <span class="c-prompt">$</span> git clone https://github.com/Creel-ai/creel.git
 <span class="c-prompt">$</span> cd creel
-<span class="c-prompt">$</span> pyenv install 3.12.12
+<span class="c-prompt">$</span> pyenv install 3.12.11
 <span class="c-prompt">$</span> uv venv && source .venv/bin/activate
 <span class="c-prompt">$</span> uv pip install -e ".[dev]"
 
-<span class="c-comment"># Configure and start the daemon</span>
-<span class="c-prompt">$</span> export ANTHROPIC_API_KEY=sk-ant-...
+<span class="c-comment"># Initialize (interactive wizard)</span>
+<span class="c-prompt">$</span> creel init
+
+<span class="c-comment"># Start the daemon</span>
 <span class="c-prompt">$</span> creel daemon start
 
 <span class="c-output">🧺 Creel daemon running. Tools loaded: 32. Guardian: active.</span>


### PR DESCRIPTION
## Summary
- Update landing page to reflect 30+ executors (was 27+), Python 3.12.12, and new integrations (clipboard, TTS)
- Add dedicated architecture page (`site/architecture/`) with system diagram, Guardian pipeline detail, isolation table, and executor grid
- Add missing mkdocs nav entries for Telegram, Browser Automation, Cron Scheduling, and GitHub executor
- Create documentation pages for 4 undocumented executors: clipboard, TTS, dev session, and host exec
- Add all 4 new executors to the security table in `docs/executors/index.md`

## Test plan
- [ ] `mkdocs build --strict` passes (verified locally)
- [ ] Open `site/index.html` in browser — verify 30+ count, Python 3.12.12, updated integrations list
- [ ] Open `site/architecture/index.html` — verify diagram, Guardian layers, executor grid render correctly
- [ ] Verify Vercel deploy preview builds successfully